### PR TITLE
Update mojo and apply language changes

### DIFF
--- a/magic.lock
+++ b/magic.lock
@@ -12,7 +12,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.11.11-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.8.0-hb921021_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.8.1-h1a47875_3.conda
@@ -39,7 +39,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.12.14-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/datasets-2.14.4-pyhd8ed1ab_0.conda
@@ -76,11 +76,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-h44a453e_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-hcb10f89_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-hcb10f89_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h3ee7192_6_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-hd595efa_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-hcb10f89_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-hcb10f89_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h08228c5_7_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-26_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
@@ -89,7 +89,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.11.1-h332b0f4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.23-h4ddbbb0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20240808-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
@@ -99,9 +99,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.32.0-h804f50b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.32.0-h0121fbd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.33.0-h2b5623c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.33.0-h0121fbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-h25350d4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-26_linux64_openblas.conda
@@ -109,10 +109,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-pthreads_h94d23a6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h081d1f1_6_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h081d1f1_7_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.2-hee588c1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hf672d98_0.conda
@@ -131,19 +131,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-25.1.0.dev2024122105-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.1.0.dev2024122105-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.1.0.dev2024122105-3.12release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.1.0.dev2024122105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/max-25.1.0.dev2025010605-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-25.1.0.dev2025010605-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/max-python-25.1.0.dev2025010605-3.12release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.1.0.dev2025010605-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.1.0.dev2024122105-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.1.0.dev2025010605-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.1.0-py312h178313f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.15-py312h98912ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.29.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-common-1.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-http-1.29.0-pyhd8ed1ab_1.conda
@@ -151,23 +151,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-sdk-1.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-semantic-conventions-0.50b0-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-h97ab989_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-h12ee42a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py312h7b63e92_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.1.0-py312h80c1187_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.1-py312h66e93f0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-5.28.2-py312h2ec8cdc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-5.28.3-py312h2ec8cdc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py312h01725c0_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.10.4-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.27.2-py312h12e396e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.7.0-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.7.1-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyinstrument-5.0.0-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.8-h9e4cc4f_1_cpython.conda
@@ -181,24 +181,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py312hbf22597_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.11.6-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.11.3-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.10-hb5b8611_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.4.5-py312h12e396e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.5.0-py312h12e396e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-2.1.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.41.3-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.21.0-py312h8360d73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.2-py312h66e93f0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/transformers-4.47.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.15.1-pyhd8ed1ab_0.conda
@@ -328,13 +328,13 @@ packages:
   timestamp: 1733247158254
 - kind: conda
   name: anyio
-  version: 4.7.0
+  version: 4.8.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
-  sha256: 687537ee3af30f8784986bf40cac30e88138770b16e51ca9850c9c23c09aeba1
-  md5: c88107912954a983c2caf25f7fd55158
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
+  sha256: f1455d2953e3eb6d71bc49881c8558d8e01888469dfd21061dd48afb6183e836
+  md5: 848d25bfbadf020ee4d4ba90e5668252
   depends:
   - exceptiongroup >=1.0.2
   - idna >=2.8
@@ -346,8 +346,8 @@ packages:
   - uvloop >=0.21
   license: MIT
   license_family: MIT
-  size: 112730
-  timestamp: 1733532678437
+  size: 115305
+  timestamp: 1736174485476
 - kind: conda
   name: attrs
   version: 24.3.0
@@ -827,20 +827,19 @@ packages:
   timestamp: 1725560714366
 - kind: conda
   name: charset-normalizer
-  version: 3.4.0
-  build: pyhd8ed1ab_1
-  build_number: 1
+  version: 3.4.1
+  build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
-  sha256: 63022ee2c6a157a9f980250a66f54bdcdf5abee817348d0f9a74c2441a6fbf0e
-  md5: 6581a17bba6b948bb60130026404a9d6
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
+  sha256: 4e0ee91b97e5de3e74567bdacea27f0139709fceca4db8adffbe24deffccb09b
+  md5: e83a31202d1c0a000fce3e9cf3825875
   depends:
   - python >=3.9
   license: MIT
   license_family: MIT
-  size: 47533
-  timestamp: 1733218182393
+  size: 47438
+  timestamp: 1735929811779
 - kind: conda
   name: click
   version: 8.1.8
@@ -1355,6 +1354,7 @@ packages:
   - markupsafe >=2.0
   - python >=3.9
   license: BSD-3-Clause
+  license_family: BSD
   size: 112561
   timestamp: 1734824044952
 - kind: conda
@@ -1481,12 +1481,12 @@ packages:
 - kind: conda
   name: libabseil
   version: '20240722.0'
-  build: cxx17_h5888daf_1
-  build_number: 1
+  build: cxx17_hbbce691_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
-  sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
-  md5: e1f604644fe8d78e22660e2fec6756bc
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
+  sha256: 143a586aa67d50622ef703de57b9d43f44945836d6568e0e7aa174bd8c45e0d4
+  md5: 488f260ccda0afaf08acb286db439c2f
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -1496,17 +1496,17 @@ packages:
   - abseil-cpp =20240722.0
   license: Apache-2.0
   license_family: Apache
-  size: 1310521
-  timestamp: 1727295454064
+  size: 1311599
+  timestamp: 1736008414161
 - kind: conda
   name: libarrow
   version: 18.1.0
-  build: h44a453e_6_cpu
-  build_number: 6
+  build: hd595efa_7_cpu
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-h44a453e_6_cpu.conda
-  sha256: abf17e99b03356a9d6248e965826c1352ff01b00d3a62cc51393bb0744d72803
-  md5: 2cf6d608d6e66506f69797d5c6944c35
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-18.1.0-hd595efa_7_cpu.conda
+  sha256: 554ffa338264c1dc34d95adb7eb856d50a2f25e7fa303a1a51e4372301b7c96f
+  md5: 08d4aff5ee6dee9a1b9ab13fca927697
   depends:
   - __glibc >=2.17,<3.0.a0
   - aws-crt-cpp >=0.29.7,<0.29.8.0a0
@@ -1523,8 +1523,8 @@ packages:
   - libbrotlidec >=1.1.0,<1.2.0a0
   - libbrotlienc >=1.1.0,<1.2.0a0
   - libgcc >=13
-  - libgoogle-cloud >=2.32.0,<2.33.0a0
-  - libgoogle-cloud-storage >=2.32.0,<2.33.0a0
+  - libgoogle-cloud >=2.33.0,<2.34.0a0
+  - libgoogle-cloud-storage >=2.33.0,<2.34.0a0
   - libre2-11 >=2024.7.2
   - libstdcxx >=13
   - libutf8proc >=2.9.0,<2.10.0a0
@@ -1535,74 +1535,74 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 8786061
-  timestamp: 1733810643966
+  size: 8770256
+  timestamp: 1735684696564
 - kind: conda
   name: libarrow-acero
   version: 18.1.0
-  build: hcb10f89_6_cpu
-  build_number: 6
+  build: hcb10f89_7_cpu
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-hcb10f89_6_cpu.conda
-  sha256: a32fa1d71415afc02b5cf3cd4c0a6ec0af9e749308829cc65ff79689222ce479
-  md5: 143f9288b64759a6427563f058c62f2b
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-18.1.0-hcb10f89_7_cpu.conda
+  sha256: 87ea5d6a84d922d73975dce8661fccf257e72e755175b12c30e1181a34e37987
+  md5: 12d84228204c56fec6ed113288014d11
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 18.1.0 h44a453e_6_cpu
+  - libarrow 18.1.0 hd595efa_7_cpu
   - libgcc >=13
   - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
-  size: 611745
-  timestamp: 1733810698469
+  size: 612463
+  timestamp: 1735684749868
 - kind: conda
   name: libarrow-dataset
   version: 18.1.0
-  build: hcb10f89_6_cpu
-  build_number: 6
+  build: hcb10f89_7_cpu
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-hcb10f89_6_cpu.conda
-  sha256: 74eeb178070002842d3ed721769399320e3a68a0843319eaf899a092a31def26
-  md5: 20ca46a6bc714a6ab189d5b3f46e66d8
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-18.1.0-hcb10f89_7_cpu.conda
+  sha256: 99c12511fba79c7947f78d676eae5857659084f687f375f68bc20bd4cddb0a0e
+  md5: 0a81eb63d7cd150f598c752e86388d57
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 18.1.0 h44a453e_6_cpu
-  - libarrow-acero 18.1.0 hcb10f89_6_cpu
+  - libarrow 18.1.0 hd595efa_7_cpu
+  - libarrow-acero 18.1.0 hcb10f89_7_cpu
   - libgcc >=13
-  - libparquet 18.1.0 h081d1f1_6_cpu
+  - libparquet 18.1.0 h081d1f1_7_cpu
   - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
-  size: 586627
-  timestamp: 1733810842604
+  size: 587497
+  timestamp: 1735684880531
 - kind: conda
   name: libarrow-substrait
   version: 18.1.0
-  build: h3ee7192_6_cpu
-  build_number: 6
+  build: h08228c5_7_cpu
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h3ee7192_6_cpu.conda
-  sha256: bda6728db019dd0c409b1996ad9ef6ab0bcee3a94dc66a8045e8c1049c566055
-  md5: aa313b3168caf98d00b3753f5ba27650
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-18.1.0-h08228c5_7_cpu.conda
+  sha256: 53ea53a06e137c2f81ebfdff3f978babb8b59e31f705a19b57056ec8754c1abf
+  md5: e128def53c133e8a23ac00cd4a479335
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
   - libabseil >=20240722.0,<20240723.0a0
-  - libarrow 18.1.0 h44a453e_6_cpu
-  - libarrow-acero 18.1.0 hcb10f89_6_cpu
-  - libarrow-dataset 18.1.0 hcb10f89_6_cpu
+  - libarrow 18.1.0 hd595efa_7_cpu
+  - libarrow-acero 18.1.0 hcb10f89_7_cpu
+  - libarrow-dataset 18.1.0 hcb10f89_7_cpu
   - libgcc >=13
-  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
   - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
-  size: 519989
-  timestamp: 1733810903274
+  size: 521861
+  timestamp: 1735684940668
 - kind: conda
   name: libblas
   version: 3.9.0
@@ -1746,20 +1746,21 @@ packages:
   timestamp: 1734373823254
 - kind: conda
   name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
+  version: 3.1.20240808
+  build: pl5321h7949ede_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20240808-pl5321h7949ede_0.conda
+  sha256: 4d0d69ddf9cc7d724a1ccf3a9852e44c8aea9825692582bac2c4e8d21ec95ccd
+  md5: 8247f80f3dc464d9322e85007e307fe8
   depends:
-  - libgcc-ng >=7.5.0
-  - ncurses >=6.2,<7.0.0a0
+  - ncurses
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
   license: BSD-2-Clause
   license_family: BSD
-  size: 123878
-  timestamp: 1597616541093
+  size: 134657
+  timestamp: 1736191912705
 - kind: conda
   name: libev
   version: '4.33'
@@ -1908,76 +1909,79 @@ packages:
   timestamp: 1729027639220
 - kind: conda
   name: libgoogle-cloud
-  version: 2.32.0
-  build: h804f50b_0
+  version: 2.33.0
+  build: h2b5623c_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.32.0-h804f50b_0.conda
-  sha256: 126856add750013390dff664a3c3cd0f6f0cbbc683b0025a7ce9d1618968bc70
-  md5: 3d96df4d6b1c88455e05b94ce8a14a53
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.33.0-h2b5623c_1.conda
+  sha256: ae48ee93e2c226bf682f1e389c2fd51ae7bf77c2ce4b3aee069764f4be1c63f2
+  md5: 61829a8dd5f4e2327e707572065bae41
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
   - libabseil >=20240722.0,<20240723.0a0
-  - libcurl >=8.10.1,<9.0a0
+  - libcurl >=8.11.1,<9.0a0
   - libgcc >=13
   - libgrpc >=1.67.1,<1.68.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
   - libstdcxx >=13
   - openssl >=3.4.0,<4.0a0
   constrains:
-  - libgoogle-cloud 2.32.0 *_0
+  - libgoogle-cloud 2.33.0 *_1
   license: Apache-2.0
   license_family: Apache
-  size: 1249557
-  timestamp: 1733512191906
+  size: 1254656
+  timestamp: 1735648569457
 - kind: conda
   name: libgoogle-cloud-storage
-  version: 2.32.0
-  build: h0121fbd_0
+  version: 2.33.0
+  build: h0121fbd_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.32.0-h0121fbd_0.conda
-  sha256: d1b53d17df38b52a4bc6d1fe6af0e611d6480ce10b0af570c84bd38c8aa83b91
-  md5: 877a5ec0431a5af83bf0cd0522bfe661
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.33.0-h0121fbd_1.conda
+  sha256: 41022523320ca8633a6c615710823e596efadb50f06d724e1a0c81e27994f257
+  md5: b0cfb5044685a7a9fa43ae669124f0a0
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil
   - libcrc32c >=1.1.2,<1.2.0a0
   - libcurl
   - libgcc >=13
-  - libgoogle-cloud 2.32.0 h804f50b_0
+  - libgoogle-cloud 2.33.0 h2b5623c_1
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   - openssl
   license: Apache-2.0
   license_family: Apache
-  size: 782108
-  timestamp: 1733512329104
+  size: 784357
+  timestamp: 1735648759177
 - kind: conda
   name: libgrpc
   version: 1.67.1
-  build: hc2c308b_0
+  build: h25350d4_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-hc2c308b_0.conda
-  sha256: 870550c1faf524e9a695262cd4c31441b18ad542f16893bd3c5dbc93106705f7
-  md5: 4606a4647bfe857e3cfe21ca12ac3afb
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.67.1-h25350d4_1.conda
+  sha256: 014627485b3cf0ea18e04c0bab07be7fb98722a3aeeb58477acc7e1c3d2f911e
+  md5: 0c6497a760b99a926c7c12b74951a39c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - c-ares >=1.32.3,<2.0a0
+  - c-ares >=1.34.4,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20240722.0,<20240723.0a0
   - libgcc >=13
-  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
   - libre2-11 >=2024.7.2
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - openssl >=3.4.0,<4.0a0
   - re2
   constrains:
   - grpc-cpp =1.67.1
   license: Apache-2.0
   license_family: APACHE
-  size: 7362336
-  timestamp: 1730236333879
+  size: 7792251
+  timestamp: 1735584856826
 - kind: conda
   name: libiconv
   version: '1.17'
@@ -2100,23 +2104,23 @@ packages:
 - kind: conda
   name: libparquet
   version: 18.1.0
-  build: h081d1f1_6_cpu
-  build_number: 6
+  build: h081d1f1_7_cpu
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h081d1f1_6_cpu.conda
-  sha256: c691a59f1ebb6cedbf827f49f6cf414e08b0eec911f589133e6a8321e8ac701c
-  md5: 68788df49ce7480187eb6387f15b2b67
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.1.0-h081d1f1_7_cpu.conda
+  sha256: 55945b761130f60abdecf1551907ecfd05cb4a5958cf74d855b30c005ecb3592
+  md5: b97013ef4e1dd2cf11594f06d5b5e83a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 18.1.0 h44a453e_6_cpu
+  - libarrow 18.1.0 hd595efa_7_cpu
   - libgcc >=13
   - libstdcxx >=13
   - libthrift >=0.21.0,<0.21.1.0a0
   - openssl >=3.4.0,<4.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 1204535
-  timestamp: 1733810811118
+  size: 1205598
+  timestamp: 1735684849150
 - kind: conda
   name: libpng
   version: 1.6.44
@@ -2134,12 +2138,13 @@ packages:
   timestamp: 1726234747153
 - kind: conda
   name: libprotobuf
-  version: 5.28.2
-  build: h5b01275_0
+  version: 5.28.3
+  build: h6128344_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
-  sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
-  md5: ab0bff36363bec94720275a681af8b83
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.3-h6128344_1.conda
+  sha256: 51125ebb8b7152e4a4e69fd2398489c4ec8473195c27cde3cbdf1cb6d18c5493
+  md5: d8703f1ffe5a06356f06467f1d0b9464
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
@@ -2149,17 +2154,17 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2945348
-  timestamp: 1728565355702
+  size: 2960815
+  timestamp: 1735577210663
 - kind: conda
   name: libre2-11
   version: 2024.07.02
-  build: hbbce691_1
-  build_number: 1
+  build: hbbce691_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
-  sha256: f8ad6a4f6d4fd54ebe3e5e712a01e663222fc57f49d16b6b8b10c30990dafb8f
-  md5: 2124de47357b7a516c0a3efd8f88c143
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_2.conda
+  sha256: 4420f8362c71251892ba1eeb957c5e445e4e1596c0c651c28d0d8b415fe120c7
+  md5: b2fede24428726dd867611664fb372e8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
@@ -2170,8 +2175,8 @@ packages:
   - re2 2024.07.02.*
   license: BSD-3-Clause
   license_family: BSD
-  size: 211096
-  timestamp: 1728778964655
+  size: 209793
+  timestamp: 1735541054068
 - kind: conda
   name: libsodium
   version: 1.0.20
@@ -2348,6 +2353,7 @@ packages:
   constrains:
   - libwebp 1.5.0
   license: BSD-3-Clause
+  license_family: BSD
   size: 429973
   timestamp: 1734777489810
 - kind: conda
@@ -2477,46 +2483,46 @@ packages:
   timestamp: 1733219911494
 - kind: conda
   name: max
-  version: 25.1.0.dev2024122105
+  version: 25.1.0.dev2025010605
   build: release
   subdir: noarch
   noarch: python
-  url: https://conda.modular.com/max-nightly/noarch/max-25.1.0.dev2024122105-release.conda
-  sha256: 1e0513f880a8177c497d6834629f07b87081c1330ea744dafc95fe46be8027a0
-  md5: f4c30ea26051f5bbf5000a3adec295e7
+  url: https://conda.modular.com/max-nightly/noarch/max-25.1.0.dev2025010605-release.conda
+  sha256: f806f7b7519e01cd68fbae2c714d1c1a9e1e96f144e920ce51c47512f81a1db3
+  md5: 1bae0e6863939e6792d7129bec77983c
   depends:
-  - max-core ==25.1.0.dev2024122105 release
-  - max-python >=25.1.0.dev2024122105,<26.0a0
-  - mojo-jupyter ==25.1.0.dev2024122105 release
-  - mblack ==25.1.0.dev2024122105 release
+  - max-core ==25.1.0.dev2025010605 release
+  - max-python >=25.1.0.dev2025010605,<26.0a0
+  - mojo-jupyter ==25.1.0.dev2025010605 release
+  - mblack ==25.1.0.dev2025010605 release
   license: LicenseRef-Modular-Proprietary
-  size: 9918
-  timestamp: 1734758299194
+  size: 9914
+  timestamp: 1736140643481
 - kind: conda
   name: max-core
-  version: 25.1.0.dev2024122105
+  version: 25.1.0.dev2025010605
   build: release
   subdir: linux-64
-  url: https://conda.modular.com/max-nightly/linux-64/max-core-25.1.0.dev2024122105-release.conda
-  sha256: 032159ddcf04826995c272caac82a2ae428dea443f7f2c6f3b382fc0efe0aa8a
-  md5: fb9e0c204a52897ac821ca65725fbbca
+  url: https://conda.modular.com/max-nightly/linux-64/max-core-25.1.0.dev2025010605-release.conda
+  sha256: 315ad791e417ed45fcee42fe7227428bca1d77427c10b81fb5a65583a5844279
+  md5: c40747b8b9245abb69db013a14266b6c
   depends:
-  - mblack ==25.1.0.dev2024122105 release
+  - mblack ==25.1.0.dev2025010605 release
   arch: x86_64
   platform: linux
   license: LicenseRef-Modular-Proprietary
-  size: 245838806
-  timestamp: 1734758213295
+  size: 244726382
+  timestamp: 1736140669107
 - kind: conda
   name: max-python
-  version: 25.1.0.dev2024122105
+  version: 25.1.0.dev2025010605
   build: 3.12release
   subdir: linux-64
-  url: https://conda.modular.com/max-nightly/linux-64/max-python-25.1.0.dev2024122105-3.12release.conda
-  sha256: ea496197a0d531c7fd9b6f61879dff9d780e7faa9ce9223a9213ac27cb6f45d3
-  md5: 06ccf6c3c46efd01d28ff4d192ff44d2
+  url: https://conda.modular.com/max-nightly/linux-64/max-python-25.1.0.dev2025010605-3.12release.conda
+  sha256: 80e1b3a95eb37bd76396c470b8a17168fdd1b0a2e193d66981824760bd82e768
+  md5: 28ecc247a48f0de9dee4f6fe6d1be095
   depends:
-  - max-core ==25.1.0.dev2024122105 release
+  - max-core ==25.1.0.dev2025010605 release
   - python 3.12.*
   - fastapi
   - httpx
@@ -2539,17 +2545,17 @@ packages:
   arch: x86_64
   platform: linux
   license: LicenseRef-Modular-Proprietary
-  size: 122928729
-  timestamp: 1734758213305
+  size: 122702106
+  timestamp: 1736140669117
 - kind: conda
   name: mblack
-  version: 25.1.0.dev2024122105
+  version: 25.1.0.dev2025010605
   build: release
   subdir: noarch
   noarch: python
-  url: https://conda.modular.com/max-nightly/noarch/mblack-25.1.0.dev2024122105-release.conda
-  sha256: baed1b93405745ade9759deffb26dc7ca1ba26ae33aa0c77a42527327d8b6825
-  md5: eea3c5abc46eae804b254ef8b6fba00e
+  url: https://conda.modular.com/max-nightly/noarch/mblack-25.1.0.dev2025010605-release.conda
+  sha256: 2166e3aa028121c737e9a7f3cde3711c8f87d83757045318467ee0d54da95fdc
+  md5: 90216ac95ad02c40a72aea621bb2d54e
   depends:
   - python >=3.9,<3.13
   - click >=8.0.0
@@ -2559,8 +2565,8 @@ packages:
   - platformdirs >=2
   - python
   license: MIT
-  size: 130807
-  timestamp: 1734758299199
+  size: 130809
+  timestamp: 1736140643485
 - kind: conda
   name: mdurl
   version: 0.1.2
@@ -2579,21 +2585,21 @@ packages:
   timestamp: 1733255681319
 - kind: conda
   name: mojo-jupyter
-  version: 25.1.0.dev2024122105
+  version: 25.1.0.dev2025010605
   build: release
   subdir: noarch
   noarch: python
-  url: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.1.0.dev2024122105-release.conda
-  sha256: da4de3db554f0079a53da970d790520c31d94b7c78b1ccb9561cdf1eff940c03
-  md5: 64ca82739f0503be3407f3b94406734e
+  url: https://conda.modular.com/max-nightly/noarch/mojo-jupyter-25.1.0.dev2025010605-release.conda
+  sha256: 5d25a6cbeb7e23d0e751085fd4a8728224f4fb46667007046322109437fde8cc
+  md5: 0d7c538d4488f3d729c380af437148e3
   depends:
-  - max-core ==25.1.0.dev2024122105 release
+  - max-core ==25.1.0.dev2025010605 release
   - python >=3.9,<3.13
   - jupyter_client >=8.6.2,<8.7
   - python
   license: LicenseRef-Modular-Proprietary
-  size: 22933
-  timestamp: 1734758299200
+  size: 22938
+  timestamp: 1736140643486
 - kind: conda
   name: multidict
   version: 6.1.0
@@ -2705,19 +2711,20 @@ packages:
 - kind: conda
   name: openssl
   version: 3.4.0
-  build: hb9d3cd8_0
+  build: h7b32b05_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-hb9d3cd8_0.conda
-  sha256: 814b9dff1847b132c676ee6cc1a8cb2d427320779b93e1b6d76552275c128705
-  md5: 23cc74f77eb99315c0360ec3533147a9
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.4.0-h7b32b05_1.conda
+  sha256: f62f6bca4a33ca5109b6d571b052a394d836956d21b25b7ffd03376abf7a481f
+  md5: 4ce6875f75469b2757a65e10a5d05e31
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=13
   license: Apache-2.0
   license_family: Apache
-  size: 2947466
-  timestamp: 1731377666602
+  size: 2937158
+  timestamp: 1736086387286
 - kind: conda
   name: opentelemetry-api
   version: 1.29.0
@@ -2849,16 +2856,16 @@ packages:
 - kind: conda
   name: orc
   version: 2.0.3
-  build: h97ab989_1
-  build_number: 1
+  build: h12ee42a_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-h97ab989_1.conda
-  sha256: 9de7e2746fde57c9b7f08ee87142014f6bb9b2d3a506839ea3e98baa99711576
-  md5: 2f46eae652623114e112df13fae311cf
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.3-h12ee42a_2.conda
+  sha256: dff5cc8023905782c86b3459055f26d4b97890e403b0698477c9fed15d8669cc
+  md5: 4f6f9f3f80354ad185e276c120eac3f0
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libprotobuf >=5.28.3,<5.28.4.0a0
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
@@ -2867,8 +2874,8 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 1189462
-  timestamp: 1733509801323
+  size: 1188881
+  timestamp: 1735630209320
 - kind: conda
   name: packaging
   version: '24.2'
@@ -2927,12 +2934,12 @@ packages:
   timestamp: 1733233471940
 - kind: conda
   name: pillow
-  version: 11.0.0
-  build: py312h7b63e92_0
+  version: 11.1.0
+  build: py312h80c1187_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py312h7b63e92_0.conda
-  sha256: 13a464bea02c0df0199c20ef6bad24a6bc336aaf55bf8d6a133d0fe664463224
-  md5: 385f46a4df6f97892503a841121a9acf
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.1.0-py312h80c1187_0.conda
+  sha256: 5c347962202b55ae4d8a463e0555c5c6ca33396266a08284bf1384399894e541
+  md5: d3894405f05b2c0f351d5de3ae26fa9c
   depends:
   - __glibc >=2.17,<3.0.a0
   - freetype >=2.12.1,<3.0a0
@@ -2940,16 +2947,16 @@ packages:
   - libgcc >=13
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
+  - libwebp-base >=1.5.0,<2.0a0
   - libxcb >=1.17.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openjpeg >=2.5.2,<3.0a0
+  - openjpeg >=2.5.3,<3.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   license: HPND
-  size: 41948418
-  timestamp: 1729065846594
+  size: 42749785
+  timestamp: 1735929845390
 - kind: conda
   name: platformdirs
   version: 4.3.6
@@ -3000,12 +3007,12 @@ packages:
   timestamp: 1733391916349
 - kind: conda
   name: protobuf
-  version: 5.28.2
+  version: 5.28.3
   build: py312h2ec8cdc_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-5.28.2-py312h2ec8cdc_0.conda
-  sha256: 4884f8161602f0148ebbc1af8d3176cec80b96c83243f68aafd651986b573817
-  md5: 586bead4a9dfa46faf88deb7d3a742bb
+  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-5.28.3-py312h2ec8cdc_0.conda
+  sha256: acb2e0ee948e3941f8ed191cb77f654e06538638aed8ccd71cbc78a15242ebbb
+  md5: 9d7e427d159c1b2d516cc047ff177c48
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -3013,11 +3020,11 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   constrains:
-  - libprotobuf 5.28.2
+  - libprotobuf 5.28.3
   license: BSD-3-Clause
   license_family: BSD
-  size: 464548
-  timestamp: 1728669645013
+  size: 464794
+  timestamp: 1731366525051
 - kind: conda
   name: pthread-stubs
   version: '0.4'
@@ -3135,37 +3142,35 @@ packages:
   timestamp: 1734571789895
 - kind: conda
   name: pydantic-settings
-  version: 2.7.0
+  version: 2.7.1
   build: pyh3cfb1c2_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.7.0-pyh3cfb1c2_0.conda
-  sha256: dd1ac7c8b6a189c8aa18f6c7df019d8f6df495300a259e3fbebdb542fc955c3b
-  md5: d9f19a7c4199249fa229891b573b6f9b
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.7.1-pyh3cfb1c2_0.conda
+  sha256: 082fb1ec29917d2c9ed6a862cb8eb9beb88c208ea62c9fef1aeb5f4f3e0e0b06
+  md5: d71d76b62bed332b037d7adfc0f3989a
   depends:
   - pydantic >=2.7.0
   - python >=3.9
   - python-dotenv >=0.21.0
   license: MIT
   license_family: MIT
-  size: 31426
-  timestamp: 1734127929720
+  size: 31822
+  timestamp: 1735650532951
 - kind: conda
   name: pygments
-  version: 2.18.0
-  build: pyhd8ed1ab_1
-  build_number: 1
+  version: 2.19.1
+  build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
-  sha256: 0d6133545f268b2b89c2617c196fc791f365b538d4057ecd636d658c3b1e885d
-  md5: b38dc0206e2a530e5c2cf11dc086b31a
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
+  sha256: 28a3e3161390a9d23bc02b4419448f8d27679d9e2c250e29849e37749c8de86b
+  md5: 232fb4577b6687b2d503ef8e254270c9
   depends:
   - python >=3.9
   license: BSD-2-Clause
-  license_family: BSD
-  size: 876700
-  timestamp: 1733221731178
+  size: 888600
+  timestamp: 1736243563082
 - kind: conda
   name: pyinstrument
   version: 5.0.0
@@ -3403,18 +3408,18 @@ packages:
 - kind: conda
   name: re2
   version: 2024.07.02
-  build: h77b4e00_1
-  build_number: 1
+  build: h9925aae_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h77b4e00_1.conda
-  sha256: c1721cb80f7201652fc9801f49c214c88aee835d957f2376e301bd40a8415742
-  md5: 01093ff37c1b5e6bf9f17c0116747d11
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_2.conda
+  sha256: d213c44958d49ce7e0d4d5b81afec23640cce5016685dbb2d23571a99caa4474
+  md5: e84ddf12bde691e8ec894b00ea829ddf
   depends:
-  - libre2-11 2024.07.02 hbbce691_1
+  - libre2-11 2024.07.02 hbbce691_2
   license: BSD-3-Clause
   license_family: BSD
-  size: 26665
-  timestamp: 1728778975855
+  size: 26786
+  timestamp: 1735541074034
 - kind: conda
   name: readline
   version: '8.2'
@@ -3526,12 +3531,12 @@ packages:
   timestamp: 1734415467047
 - kind: conda
   name: safetensors
-  version: 0.4.5
+  version: 0.5.0
   build: py312h12e396e_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.4.5-py312h12e396e_0.conda
-  sha256: e44515f875c10efb5e041efcb250dfd18f2cb66ec3f268237549ead6284c6922
-  md5: 3b87a00bcaab069172d6cef8124b7142
+  url: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.5.0-py312h12e396e_0.conda
+  sha256: f9d0a4fbfbd2bcded116b81afd69d00aa5d5bac0d431dd47737cec1b1d24c2e2
+  md5: 4b33e7c3e9bbc3936e08150fc9e17708
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -3541,8 +3546,8 @@ packages:
   - __glibc >=2.17
   license: Apache-2.0
   license_family: APACHE
-  size: 402547
-  timestamp: 1725632183154
+  size: 424699
+  timestamp: 1735917812729
 - kind: conda
   name: shellingham
   version: 1.5.4
@@ -3609,22 +3614,21 @@ packages:
   timestamp: 1733244175724
 - kind: conda
   name: sse-starlette
-  version: 2.1.3
+  version: 2.2.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-2.1.3-pyhd8ed1ab_0.conda
-  sha256: 6d671a66333410ec7e5e7858a252565a9001366726d1fe3c3a506d7156169085
-  md5: 3918255c942c242ed5599e10329e8d0e
+  url: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-2.2.1-pyhd8ed1ab_0.conda
+  sha256: 3c6a476e7afb702d841e23c61a0c4cc491929d2e39376d329e67e94c40a236cc
+  md5: c1ef6bc13dd2caa4b406fb3cb06c2791
   depends:
-  - anyio
-  - python >=3.8
-  - starlette
-  - uvicorn
+  - anyio >=4.7.0
+  - python >=3.9
+  - starlette >=0.41.3
   license: BSD-3-Clause
   license_family: BSD
-  size: 14712
-  timestamp: 1722520112550
+  size: 15324
+  timestamp: 1735126414893
 - kind: conda
   name: starlette
   version: 0.41.3
@@ -3701,18 +3705,19 @@ packages:
 - kind: conda
   name: tqdm
   version: 4.67.1
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_0.conda
-  sha256: 5673b7104350a6998cb86cccf1d0058217d86950e8d6c927d8530606028edb1d
-  md5: 4085c9db273a148e149c03627350e22c
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+  sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
+  md5: 9efbfdc37242619130ea42b1cc4ed861
   depends:
   - colorama
-  - python >=3.7
+  - python >=3.9
   license: MPL-2.0 or MIT
-  size: 89484
-  timestamp: 1732497312317
+  size: 89498
+  timestamp: 1735661472632
 - kind: conda
   name: traitlets
   version: 5.14.3

--- a/src/archetype.mojo
+++ b/src/archetype.mojo
@@ -187,11 +187,11 @@ struct Archetype(CollectionElement, CollectionElementNew):
                 )
                 self._component_count += 1
 
-    fn copy(self) -> Self as other:
+    fn copy(self, out other: Self):
         """Initializes the archetype as a copy of another archetype."""
         other = self
 
-    fn __moveinit__(inout self, owned existing: Self):
+    fn __moveinit__(mut self, owned existing: Self):
         self._data = existing._data^
         self._size = existing._size
         self._capacity = existing._capacity
@@ -202,7 +202,7 @@ struct Archetype(CollectionElement, CollectionElementNew):
         self._node_index = existing._node_index
         self._mask = existing._mask
 
-    fn __copyinit__(inout self, existing: Self):
+    fn __copyinit__(mut self, existing: Self):
         # Copy the attributes that can be trivially
         # copied via a simple assignment
         self._size = existing._size
@@ -254,11 +254,11 @@ struct Archetype(CollectionElement, CollectionElementNew):
         return self._mask
 
     @always_inline
-    fn reserve(inout self):
+    fn reserve(mut self):
         """Extends the capacity of the archetype by factor 2."""
         self.reserve(self._capacity * 2)
 
-    fn reserve(inout self, new_capacity: UInt):
+    fn reserve(mut self, new_capacity: UInt):
         """Extends the capacity of the archetype to a given number.
 
         Does nothing if the new capacity is not larger than the current capacity.
@@ -291,7 +291,7 @@ struct Archetype(CollectionElement, CollectionElementNew):
 
     @always_inline
     fn unsafe_set(
-        inout self, index: Int, id: Self.Id, value: UnsafePointer[UInt8]
+        mut self, index: Int, id: Self.Id, value: UnsafePointer[UInt8]
     ):
         """Sets the component with the given id at the given index."""
         memcpy(
@@ -303,7 +303,7 @@ struct Archetype(CollectionElement, CollectionElementNew):
     @always_inline
     fn set[
         assert_has_component: Bool = True
-    ](inout self, index: UInt, value: ComponentReference) raises:
+    ](mut self, index: UInt, value: ComponentReference) raises:
         """Sets the component with the given id at the given index.
 
         Parameters:
@@ -320,7 +320,7 @@ struct Archetype(CollectionElement, CollectionElementNew):
 
         self.unsafe_set(index, value.get_id(), value.get_unsafe_ptr())
 
-    # fn get(inout self, index: UInt, id: Self.Id) -> ComponentReference[__origin_of(self)]:
+    # fn get(mut self, index: UInt, id: Self.Id) -> ComponentReference[__origin_of(self)]:
     #     """Returns the component with the given id at the given index."""
     #     return ComponentReference[__origin_of(self)](id, self._get_component_ptr(index, id))
 
@@ -331,7 +331,7 @@ struct Archetype(CollectionElement, CollectionElementNew):
         """Returns the component with the given id at the given index."""
         return self._data[int(id)] + index * int(self._item_sizes[int(id)])
 
-    fn unsafe_copy_to(self, inout other: Self, index: UInt, other_index: UInt):
+    fn unsafe_copy_to(self, mut other: Self, index: UInt, other_index: UInt):
         """Copies all components of the entity at the given index to another archetype.
 
         Caution: This function does not check whether the other archetype
@@ -385,7 +385,7 @@ struct Archetype(CollectionElement, CollectionElementNew):
                 "Archetype does not contain component with id " + str(id) + "."
             )
 
-    fn remove(inout self, index: UInt) -> Bool:
+    fn remove(mut self, index: UInt) -> Bool:
         """Removes an entity and its components from the archetype.
 
         Performs a swap-remove and reports whether a swap was necessary
@@ -418,7 +418,7 @@ struct Archetype(CollectionElement, CollectionElementNew):
 
         return swapped
 
-    fn add(inout self, entity: Entity) -> Int:
+    fn add(mut self, entity: Entity) -> Int:
         """Adds an entity to the archetype.
 
         Args:
@@ -435,8 +435,10 @@ struct Archetype(CollectionElement, CollectionElementNew):
         return self._size - 1
 
     fn extend(
-        inout self, count: Int, inout entity_pool: EntityPool
-    ) -> Int as start_index:
+        mut self,
+        count: Int,
+        mut entity_pool: EntityPool,
+    ) -> Int:
         """Extends the archetype by `count` entities from the provided pool.
 
         Args:
@@ -456,3 +458,4 @@ struct Archetype(CollectionElement, CollectionElementNew):
         for _ in range(count):
             self._entities.append(entity_pool.get())
         self._size += count
+        return start_index

--- a/src/bitmask_benchmark.mojo
+++ b/src/bitmask_benchmark.mojo
@@ -6,7 +6,7 @@ from bitmask_test import get_random_bitmask
 from bitmask import BitMask
 
 
-fn benchmark_bitmask_get_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_bitmask_get_1_000_000(mut bencher: Bencher) capturing:
     mask = get_random_bitmask()
     val = random.random_ui64(0, BitMask.total_bits).cast[DType.uint8]()
 
@@ -19,7 +19,7 @@ fn benchmark_bitmask_get_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_bitmask_set_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_bitmask_set_1_000_000(mut bencher: Bencher) capturing:
     mask = get_random_bitmask()
     val = random.random_ui64(0, BitMask.total_bits).cast[DType.uint8]()
 
@@ -35,7 +35,7 @@ fn benchmark_bitmask_set_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_bitmask_flip_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_bitmask_flip_1_000_000(mut bencher: Bencher) capturing:
     mask = get_random_bitmask()
     val = random.random_ui64(0, BitMask.total_bits).cast[DType.uint8]()
 
@@ -49,7 +49,7 @@ fn benchmark_bitmask_flip_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_bitmask_contains_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_bitmask_contains_1_000_000(mut bencher: Bencher) capturing:
     mask = get_random_bitmask()
     val = BitMask(random.random_ui64(0, BitMask.total_bits).cast[DType.uint8]())
 
@@ -62,7 +62,7 @@ fn benchmark_bitmask_contains_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_bitmask_contains_any_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_bitmask_contains_any_1_000_000(mut bencher: Bencher) capturing:
     mask = get_random_bitmask()
     val = BitMask(random.random_ui64(0, BitMask.total_bits).cast[DType.uint8]())
 
@@ -75,7 +75,7 @@ fn benchmark_bitmask_contains_any_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_mask_filter_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_mask_filter_1_000_000(mut bencher: Bencher) capturing:
     mask = BitMask(0, 1, 2).without()
     bits = BitMask(0, 1, 2)
 
@@ -88,7 +88,7 @@ fn benchmark_mask_filter_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_bitmask_eq_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_bitmask_eq_1_000_000(mut bencher: Bencher) capturing:
     mask1 = get_random_bitmask()
     mask2 = mask1
     mask3 = get_random_bitmask()
@@ -103,7 +103,7 @@ fn benchmark_bitmask_eq_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_bitmask_get_indices_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_bitmask_get_indices_1_000_000(mut bencher: Bencher) capturing:
     mask = get_random_bitmask()
 
     @always_inline
@@ -119,7 +119,7 @@ fn benchmark_bitmask_get_indices_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_bitmask_get_each_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_bitmask_get_each_1_000_000(mut bencher: Bencher) capturing:
     mask = get_random_bitmask()
 
     @always_inline
@@ -183,7 +183,7 @@ fn run_all_bitmask_benchmarks() raises:
     bench.dump_report()
 
 
-fn run_all_bitmask_benchmarks(inout bench: Bench) raises:
+fn run_all_bitmask_benchmarks(mut bench: Bench) raises:
     bench.bench_function[benchmark_bitmask_get_1_000_000](
         BenchId("10^6 * bitmask_get")
     )

--- a/src/bitmask_test.mojo
+++ b/src/bitmask_test.mojo
@@ -10,15 +10,16 @@ from custom_benchmark import Bencher, keep, Bench, BenchId, BenchConfig
 
 
 @always_inline
-fn get_random_bitmask() -> BitMask as mask:
+fn get_random_bitmask() -> BitMask:
     mask = BitMask()
     for i in range(BitMask.total_bits):
         if random.random_float64() < 0.5:
             mask.set(UInt8(i), True)
+    return mask
 
 
 @always_inline
-fn get_random_uint8_list(size: Int) -> List[UInt8] as vals:
+fn get_random_uint8_list(size: Int, out vals: List[UInt8]):
     vals = List[UInt8](capacity=size)
     for _ in range(size):
         vals.append(
@@ -26,7 +27,7 @@ fn get_random_uint8_list(size: Int) -> List[UInt8] as vals:
         )
 
 
-fn unique(l: List[UInt8]) -> List[UInt8] as result:
+fn unique(l: List[UInt8], out result: List[UInt8]):
     mask = InlineArray[Bool, 256](0)
     result = List[UInt8]()
     for v in l:
@@ -36,7 +37,7 @@ fn unique(l: List[UInt8]) -> List[UInt8] as result:
 
 
 @always_inline
-fn get_random_1_true_bitmasks(size: Int) -> List[BitMask] as vals:
+fn get_random_1_true_bitmasks(size: Int, out vals: List[BitMask]):
     vals = List[BitMask](capacity=size)
     for _ in range(size):
         vals.append(

--- a/src/chained_array_list.mojo
+++ b/src/chained_array_list.mojo
@@ -33,7 +33,7 @@ from memory import UnsafePointer
 #         return self
 
 #     fn __next__(
-#         inout self,
+#         mut self,
 #     ) -> Pointer[T, list_origin]:
 #         @parameter
 #         if forward:
@@ -79,19 +79,19 @@ struct ChainedArrayList[
     var _removed_indices: List[Int]
     var _is_alive: List[Bool]
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         """Create a new empty list."""
         self._pages = List[Self.PageType]()
         self._removed_indices = List[Int]()
         self._is_alive = List[Bool]()
 
-    fn __init__(inout self, owned *elements: ElementType):
+    fn __init__(mut self, owned *elements: ElementType):
         """Create a new empty list."""
         self = Self()
         for element in elements:
             _ = self.add(element[].copy())
 
-    fn __moveinit__(inout self, owned other: Self):
+    fn __moveinit__(mut self, owned other: Self):
         """Move the contents of another list into a new list."""
         self._pages = other._pages^
         self._removed_indices = other._removed_indices^
@@ -151,7 +151,7 @@ struct ChainedArrayList[
         return (self._pages[idx // Self.page_size] + idx % Self.page_size)[]
 
     @always_inline
-    fn remove(inout self: Self, owned idx: Int):
+    fn remove(mut self: Self, owned idx: Int):
         """Mark the element at the given index for removal.
 
         The item is not deleted immediately, but will be overwritte
@@ -193,7 +193,7 @@ struct ChainedArrayList[
     #     """
     #     return _ChainedArrayListIter(0, Pointer.address_of(self))
 
-    fn add(inout self, owned value: ElementType) -> Int as idx:
+    fn add(mut self, owned value: ElementType) -> Int:
         """Append an element to the list.
 
         Args:
@@ -203,7 +203,7 @@ struct ChainedArrayList[
             idx = self._removed_indices.pop()
             self._is_alive[idx] = True
             self[idx] = value^
-            return
+            return idx
 
         idx = len(self._is_alive)
         self._is_alive.append(True)
@@ -215,3 +215,4 @@ struct ChainedArrayList[
         (self._pages[page_index] + idx % Self.page_size).init_pointee_move(
             value^
         )
+        return idx

--- a/src/chained_array_list_test.mojo
+++ b/src/chained_array_list_test.mojo
@@ -7,14 +7,14 @@ struct TestElement(CollectionElementNew):
     var value: Int
     var dealloc_counter: ArcPointer[Int]
 
-    fn __init__(inout self, value: Int, dealloc_counter: ArcPointer[Int]):
+    fn __init__(mut self, value: Int, dealloc_counter: ArcPointer[Int]):
         self.value = value
         self.dealloc_counter = dealloc_counter
 
-    fn copy(self) -> Self as other:
+    fn copy(self, out other: Self):
         other = Self(self.value, self.dealloc_counter)
 
-    fn __moveinit__(inout self, owned other: Self):
+    fn __moveinit__(mut self, owned other: Self):
         self.value = other.value
         self.dealloc_counter = other.dealloc_counter
 

--- a/src/component.mojo
+++ b/src/component.mojo
@@ -76,17 +76,15 @@ struct ComponentReference[is_mutable: Bool, //, origin: Origin[is_mutable]]:
     var _id: Self.Id
     var _data: UnsafePointer[UInt8]
 
-    fn __init__[
-        T: ComponentType
-    ](inout self, id: Self.Id, ref [origin]value: T):
+    fn __init__[T: ComponentType](mut self, id: Self.Id, ref [origin]value: T):
         self._id = id
         self._data = UnsafePointer.address_of(value).bitcast[UInt8]()
 
-    fn __moveinit__(inout self, owned existing: Self):
+    fn __moveinit__(mut self, owned existing: Self):
         self._id = existing._id
         self._data = existing._data
 
-    fn __copyinit__(inout self, existing: Self):
+    fn __copyinit__(mut self, existing: Self):
         self._id = existing._id
         self._data = existing._data
 
@@ -145,7 +143,7 @@ struct ComponentManager[*component_types: ComponentType]:
     alias max_size = get_max_uint_size[Self.Id]()
     alias component_count = len(VariadicList(component_types))
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         constrained[
             Self.dType.is_integral(),
             "dType needs to be an integral type.",
@@ -184,10 +182,12 @@ struct ComponentManager[*component_types: ComponentType]:
     @always_inline
     fn get_id_arr[
         *Ts: ComponentType
-    ]() -> InlineArray[
-        Self.Id,
-        VariadicPack[MutableAnyOrigin, ComponentType, *Ts].__len__(),
-    ] as ids:
+    ](
+        out ids: InlineArray[
+            Self.Id,
+            VariadicPack[MutableAnyOrigin, ComponentType, *Ts].__len__(),
+        ]
+    ):
         """Get the IDs of multiple component types.
 
         Parameters:
@@ -218,10 +218,12 @@ struct ComponentManager[*component_types: ComponentType]:
     @always_inline
     fn get_info_arr[
         *Ts: ComponentType
-    ]() -> InlineArray[
-        ComponentInfo,
-        VariadicPack[MutableAnyOrigin, ComponentType, *Ts].__len__(),
-    ] as ids:
+    ](
+        out ids: InlineArray[
+            ComponentInfo,
+            VariadicPack[MutableAnyOrigin, ComponentType, *Ts].__len__(),
+        ]
+    ):
         """Get the IDs of multiple component types.
 
         Parameters:

--- a/src/component_benchmark.mojo
+++ b/src/component_benchmark.mojo
@@ -265,7 +265,7 @@ alias FullManager = ComponentManager[
 ]
 
 
-fn benchmark_get_first_id_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_get_first_id_1_000_000(mut bencher: Bencher) capturing:
     # create a component manager with 256 components
     manager = FullManager()
 
@@ -278,7 +278,7 @@ fn benchmark_get_first_id_1_000_000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_get_last_id_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_get_last_id_1_000_000(mut bencher: Bencher) capturing:
     # create a component manager with 256 components
     manager = FullManager()
 
@@ -299,7 +299,7 @@ fn t[size: Int](arr: InlineArray[UInt8, size]) -> UInt8:
     return arr[0]
 
 
-fn benchmark_get_5_id_arr_1_000_000(inout bencher: Bencher) capturing:
+fn benchmark_get_5_id_arr_1_000_000(mut bencher: Bencher) capturing:
     # create a component manager with 256 components
     manager = FullManager()
 
@@ -325,7 +325,7 @@ def run_all_component_benchmarks():
     bench.dump_report()
 
 
-def run_all_component_benchmarks(inout bench: Bench):
+def run_all_component_benchmarks(mut bench: Bench):
     bench.bench_function[benchmark_get_first_id_1_000_000](
         BenchId("10^6 * component_get_id[0]")
     )

--- a/src/component_test.mojo
+++ b/src/component_test.mojo
@@ -12,7 +12,7 @@ struct DummyComponentType(EqualityComparable, Stringable):
     fn get_type_identifier() -> Int:
         return 12345
 
-    fn __init__(inout self, x: Int32):
+    fn __init__(mut self, x: Int32):
         self.x = x
 
     fn __eq__(self, other: Self) -> Bool:
@@ -24,10 +24,10 @@ struct DummyComponentType(EqualityComparable, Stringable):
     fn __str__(self) -> String:
         return "DummyComponentType(x: " + str(self.x) + ")"
 
-    fn __copyinit__(inout self, existing: Self):
+    fn __copyinit__(mut self, existing: Self):
         self.x = existing.x
 
-    fn __moveinit__(inout self, owned existing: Self):
+    fn __moveinit__(mut self, owned existing: Self):
         self.x = existing.x
 
     fn __del__(owned self):

--- a/src/custom_benchmark.mojo
+++ b/src/custom_benchmark.mojo
@@ -47,7 +47,7 @@ struct Bencher:
         self._time_ns = 0
         self._iters = 0
 
-    fn iter_custom[iter_fn: fn (Int) capturing -> Int](inout self: Self):
+    fn iter_custom[iter_fn: fn (Int) capturing -> Int](mut self: Self):
         """Times the execution of the given function.
 
         Parameters:
@@ -61,7 +61,7 @@ struct Bencher:
         time_passed = perf_counter_ns() - start
         self._time_ns += time_passed
 
-    fn reset_time(inout self: Self):
+    fn reset_time(mut self: Self):
         """Resets the time and iteration counters."""
         self._time_ns = 0
         self._iters = 0
@@ -148,8 +148,8 @@ struct Bench:
         self._results = List[Tuple[BenchId, Bencher]]()
 
     fn _bench_function_once[
-        bench_fn: fn (inout Bencher) capturing -> None
-    ](inout self, inout bencher: Bencher):
+        bench_fn: fn (mut Bencher) capturing -> None
+    ](mut self, mut bencher: Bencher):
         """Benchmarks the given function once and adjusts the batch size if required.
 
         Parameters:
@@ -176,8 +176,8 @@ struct Bench:
             return self._bench_function_once[bench_fn](bencher)
 
     fn bench_function[
-        bench_fn: fn (inout Bencher) capturing -> None
-    ](inout self, bench_id: BenchId):
+        bench_fn: fn (mut Bencher) capturing -> None
+    ](mut self, bench_id: BenchId):
         """Benchmarks the given function.
 
         Parameters:
@@ -208,7 +208,7 @@ struct Bench:
 
         self._results.append((bench_id, bencher))
 
-    fn dump_report(inout self):
+    fn dump_report(mut self):
         """Prints the results of the benchmarking."""
 
         for tuple in self._results:

--- a/src/dict_benchmark.mojo
+++ b/src/dict_benchmark.mojo
@@ -6,7 +6,7 @@ from stupid_dict import StupidDict
 from bitmask import BitMask
 
 
-fn benchmark_dict_insert_1000(inout bencher: Bencher) capturing:
+fn benchmark_dict_insert_1000(mut bencher: Bencher) capturing:
     bitmasks = get_random_bitmask_list(1000)
     dict = StupidDict[BitMask, Int]()
 
@@ -19,7 +19,7 @@ fn benchmark_dict_insert_1000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_dict_get_1000(inout bencher: Bencher) capturing:
+fn benchmark_dict_get_1000(mut bencher: Bencher) capturing:
     bitmasks = get_random_bitmask_list(1000)
     bitmask_count = len(bitmasks)
 
@@ -42,7 +42,7 @@ fn benchmark_dict_get_1000(inout bencher: Bencher) capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_dict_contains_1000(inout bencher: Bencher) capturing:
+fn benchmark_dict_contains_1000(mut bencher: Bencher) capturing:
     bitmasks = get_random_bitmask_list(1000)
     bitmask_count = len(bitmasks)
 
@@ -68,7 +68,7 @@ fn run_all_dict_benchmarks() raises:
     bench.dump_report()
 
 
-fn run_all_dict_benchmarks(inout bench: Bench) raises:
+fn run_all_dict_benchmarks(mut bench: Bench) raises:
     bench.bench_function[benchmark_dict_insert_1000](
         BenchId("10^3 * dict_insert")
     )

--- a/src/entity.mojo
+++ b/src/entity.mojo
@@ -30,7 +30,7 @@ struct Entity(EqualityComparable, Stringable, Hashable):
     var gen: UInt16  # Entity generation
 
     @always_inline
-    fn __init__(inout self, id: EntityId = 0, gen: UInt16 = 0):
+    fn __init__(mut self, id: EntityId = 0, gen: UInt16 = 0):
         self.id = id
         self.gen = gen
 
@@ -51,7 +51,7 @@ struct Entity(EqualityComparable, Stringable, Hashable):
         return "Entity(" + str(self.id) + ", " + str(self.gen) + ")"
 
     @always_inline
-    fn __hash__(self) -> UInt as output:
+    fn __hash__(self, out output: UInt):
         """Returns a unique hash."""
         output = int(self.id)
         output |= bit_reverse(int(self.gen))

--- a/src/entity_test.mojo
+++ b/src/entity_test.mojo
@@ -18,7 +18,7 @@ def test_zero_entity():
     assert_false(Entity(1, 0).is_zero())
 
 
-fn benchmark_entity_is_zero(inout bencher: Bencher) capturing:
+fn benchmark_entity_is_zero(mut bencher: Bencher) capturing:
     e = Entity()
 
     @parameter

--- a/src/graph.mojo
+++ b/src/graph.mojo
@@ -29,7 +29,7 @@ struct Node[DataType: KeyElement](CollectionElement):
     # The mask of the node.
     var bit_mask: BitMask
 
-    fn __init__(inout self, owned bit_mask: BitMask, owned value: DataType):
+    fn __init__(mut self, owned bit_mask: BitMask, owned value: DataType):
         """Initializes the node with the given mask and value.
 
         Args:
@@ -75,7 +75,7 @@ struct BitMaskGraph[
     # Used for slow lookup of nodes.
     var _map: Dict[BitMask, Int]
 
-    fn __init__(inout self, owned first_value: DataType = Self.null_value):
+    fn __init__(mut self, owned first_value: DataType = Self.null_value):
         """Initializes the graph.
 
         Args:
@@ -90,7 +90,7 @@ struct BitMaskGraph[
 
     @always_inline
     fn add_node(
-        inout self,
+        mut self,
         owned node_mask: BitMask,
         owned value: DataType = Self.null_value,
     ) -> Int:
@@ -109,7 +109,7 @@ struct BitMaskGraph[
 
     @always_inline
     fn create_link(
-        inout self, from_node_index: Int, changed_bit: BitMask.IndexType
+        mut self, from_node_index: Int, changed_bit: BitMask.IndexType
     ) -> Int:
         """Creates a link between two nodes.
 
@@ -142,7 +142,7 @@ struct BitMaskGraph[
     fn get_node_index[
         T: Intable, size: Int
     ](
-        inout self,
+        mut self,
         different_bits: InlineArray[T, size],
         start_node_index: Int = 0,
     ) -> Int:

--- a/src/graph_test.mojo
+++ b/src/graph_test.mojo
@@ -81,11 +81,11 @@ def test_get_node_mask():
 struct S:
     var l: List[Node[Int]]
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self.l = List[Node[Int]]()
         self.add(BitMask(), -1)
 
-    fn add(inout self, owned node_mask: BitMask, owned value: Int):
+    fn add(mut self, owned node_mask: BitMask, owned value: Int):
         self.l.append(Node(node_mask, value))
 
 

--- a/src/lock.mojo
+++ b/src/lock.mojo
@@ -14,12 +14,12 @@ struct LockMask:
     var bit_pool: BitPool  # The bit pool for getting and recycling bits.
 
     @always_inline
-    fn __init__(inout self):
+    fn __init__(mut self):
         self.locks = BitMask()
         self.bit_pool = BitPool()
 
     @always_inline
-    fn lock(inout self) raises -> UInt8:
+    fn lock(mut self) raises -> UInt8:
         """
         Locks the world and gets the Lock bit for later unlocking.
 
@@ -31,7 +31,7 @@ struct LockMask:
         return lock
 
     @always_inline
-    fn unlock(inout self, lock: UInt8) raises:
+    fn unlock(mut self, lock: UInt8) raises:
         """
         Unlocks the given lock bit.
 
@@ -55,7 +55,7 @@ struct LockMask:
         return not self.locks.is_zero()
 
     @always_inline
-    fn reset(inout self):
+    fn reset(mut self):
         """
         Reset the locks and the pool.
         """

--- a/src/pool.mojo
+++ b/src/pool.mojo
@@ -18,13 +18,13 @@ struct EntityPool:
     var _next: EntityId
     var _available: UInt32
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self._entities = List[Entity]()
         self._entities.append(Entity(0, MAX_UINT16))
         self._next = 0
         self._available = 0
 
-    fn get(inout self) -> Entity:
+    fn get(mut self) -> Entity:
         """Returns a fresh or recycled entity."""
         if self._available == 0:
             return self._get_new()
@@ -37,12 +37,12 @@ struct EntityPool:
         self._available -= 1
         return self._entities[int(curr)]
 
-    fn _get_new(inout self) -> Entity as entity:
+    fn _get_new(mut self, out entity: Entity):
         """Allocates and returns a new entity. For internal use."""
         entity = Entity(EntityId(len(self._entities)))
         self._entities.append(entity)
 
-    fn recycle(inout self, enitity: Entity) raises:
+    fn recycle(mut self, enitity: Entity) raises:
         """Hands an entity back for recycling."""
         if enitity.id == 0:
             raise Error("Can't recycle reserved zero entity")
@@ -51,7 +51,7 @@ struct EntityPool:
         self._next, self._entities[int(enitity.id)].id = enitity.id, self._next
         self._available += 1
 
-    fn reset(inout self):
+    fn reset(mut self):
         """Recycles all entities. Does NOT free the reserved memory."""
         self._entities.resize(1)
         self._next = 0
@@ -100,13 +100,13 @@ struct BitPool[LengthDType: DType = DType.uint16]:
     var _length: Self.LengthType
     var _available: UInt8
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self._bits = SIMD[DType.uint8, Self.capacity]()
         self._next = 0
         self._length = 0
         self._available = 0
 
-    fn get(inout self) raises -> UInt8:
+    fn get(mut self) raises -> UInt8:
         """Returns a fresh or recycled bit.
 
         Raises:
@@ -123,7 +123,7 @@ struct BitPool[LengthDType: DType = DType.uint16]:
         self._available -= 1
         return self._bits[int(curr)]
 
-    fn _get_new(inout self) raises -> UInt8 as bit:
+    fn _get_new(mut self) raises -> UInt8:
         """Allocates and returns a new bit. For internal use.
 
         Raises:
@@ -139,14 +139,14 @@ struct BitPool[LengthDType: DType = DType.uint16]:
         bit = UInt8(int(self._length))
         self._bits[int(self._length)] = bit
         self._length += 1
-        return
+        return bit
 
-    fn recycle(inout self, bit: UInt8):
+    fn recycle(mut self, bit: UInt8):
         """Hands a bit back for recycling."""
         self._next, self._bits[int(bit)] = bit, self._next
         self._available += 1
 
-    fn reset(inout self):
+    fn reset(mut self):
         """Recycles all bits."""
         self._next = 0
         self._length = 0
@@ -163,13 +163,13 @@ struct IntPool[ElementType: IntableCollectionElement = Int]:
     var _next: ElementType
     var _available: UInt32
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         """Creates a new, initialized entity pool."""
         self._pool = List[ElementType, True]()
         self._next = ElementType(0)
         self._available = 0
 
-    fn get(inout self) -> ElementType:
+    fn get(mut self) -> ElementType:
         """Returns a fresh or recycled entity."""
         if self._available == 0:
             return self._get_new()
@@ -182,18 +182,18 @@ struct IntPool[ElementType: IntableCollectionElement = Int]:
         self._available -= 1
         return self._pool[int(curr)]
 
-    fn _get_new(inout self) -> ElementType:
+    fn _get_new(mut self) -> ElementType:
         """Allocates and returns a new entity. For internal use."""
         element = ElementType(len(self._pool))
         self._pool.append(element)
         return element
 
-    fn recycle(inout self, element: ElementType):
+    fn recycle(mut self, element: ElementType):
         """Hands an entity back for recycling."""
         self._next, self._pool[int(element)] = element, self._next
         self._available += 1
 
-    fn reset(inout self):
+    fn reset(mut self):
         """Recycles all _entities. Does NOT free the reserved memory."""
         self._pool.clear()
         self._next = ElementType(0)

--- a/src/query.mojo
+++ b/src/query.mojo
@@ -47,7 +47,7 @@ struct _EntityAccessor[
         self._index_in_archetype = index_in_archetype
 
     @always_inline
-    fn get[T: ComponentType](inout self) raises -> ref [self._archetype] T:
+    fn get[T: ComponentType](mut self) raises -> ref [self._archetype] T:
         """Returns a reference to the given component of the Entity.
 
         Raises:
@@ -65,7 +65,7 @@ struct _EntityAccessor[
     @always_inline
     fn get_ptr[
         T: ComponentType
-    ](inout self) raises -> Pointer[T, __origin_of(self._archetype)]:
+    ](mut self) raises -> Pointer[T, __origin_of(self._archetype)]:
         """Returns a reference to the given component of the Entity.
 
         Raises:
@@ -203,10 +203,10 @@ struct _EntityIterator[
             debug_warn("Failed to unlock the lock. This should not happen.")
 
     @always_inline
-    fn __iter__(owned self) -> Self as iterator:
+    fn __iter__(owned self, out iterator: Self):
         iterator = self^
 
-    fn _fill_archetype_buffer(inout self):
+    fn _fill_archetype_buffer(mut self):
         """
         Find the next archetypes that contain the mask.
 
@@ -232,7 +232,7 @@ struct _EntityIterator[
         self._max_buffer_index = buffer_index - 1
 
     @always_inline
-    fn _next_archetype(inout self):
+    fn _next_archetype(mut self):
         """
         Moves to the next archetype.
         """
@@ -254,10 +254,11 @@ struct _EntityIterator[
 
     @always_inline
     fn __next__(
-        inout self,
-    ) -> _EntityAccessor[
-        __origin_of(self._current_archetype[]), *component_types
-    ] as accessor:
+        mut self,
+        out accessor: _EntityAccessor[
+            __origin_of(self._current_archetype[]), *component_types
+        ],
+    ):
         self._entity_index += 1
         if self._entity_index >= self._archetype_size:
             self._next_archetype()

--- a/src/query_benchmark.mojo
+++ b/src/query_benchmark.mojo
@@ -6,7 +6,7 @@ from component import ComponentType, ComponentInfo
 from test_utils import *
 
 
-fn benchmark_new_entity_1_000_000(inout bencher: Bencher) raises capturing:
+fn benchmark_new_entity_1_000_000(mut bencher: Bencher) raises capturing:
     @always_inline
     @parameter
     fn bench_fn() capturing raises:
@@ -18,7 +18,7 @@ fn benchmark_new_entity_1_000_000(inout bencher: Bencher) raises capturing:
 
 
 fn benchmark_query_1_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     pos = Position(1.0, 2.0)
 
@@ -36,7 +36,7 @@ fn benchmark_query_1_comp_1_000_000(
 
 
 fn benchmark_query_2_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     pos = Position(1.0, 2.0)
     vel = Velocity(0.1, 0.2)
@@ -56,7 +56,7 @@ fn benchmark_query_2_comp_1_000_000(
 
 
 fn benchmark_query_2_comp_ptr_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     pos = Position(1.0, 2.0)
     vel = Velocity(0.1, 0.2)
@@ -76,7 +76,7 @@ fn benchmark_query_2_comp_ptr_1_000_000(
 
 
 fn benchmark_query_5_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     c1 = FlexibleComponent[1](3.0, 4.0)
     c2 = FlexibleComponent[2](5.0, 6.0)
@@ -108,7 +108,7 @@ fn benchmark_query_5_comp_1_000_000(
 
 
 fn benchmark_query_get_iter_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     c1 = FlexibleComponent[1](3.0, 4.0)
     c2 = FlexibleComponent[2](5.0, 6.0)
@@ -128,7 +128,7 @@ fn benchmark_query_get_iter_1_000_000(
 
 
 fn benchmark_query_has_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     c1 = FlexibleComponent[1](3.0, 4.0)
     c2 = FlexibleComponent[2](5.0, 6.0)
@@ -154,7 +154,7 @@ fn run_all_query_benchmarks() raises:
     bench.dump_report()
 
 
-fn run_all_query_benchmarks(inout bench: Bench) raises:
+fn run_all_query_benchmarks(mut bench: Bench) raises:
     bench.bench_function[benchmark_query_has_1_000_000](
         BenchId("10^6 * query has")
     )

--- a/src/stupid_dict.mojo
+++ b/src/stupid_dict.mojo
@@ -9,7 +9,7 @@ struct StupidDict[KeyType: KeyElement, ValueType: CollectionElement]:
 
     var _data: List[Tuple[KeyType, ValueType]]
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self._data = List[Tuple[KeyType, ValueType]]()
 
     @always_inline
@@ -33,7 +33,7 @@ struct StupidDict[KeyType: KeyElement, ValueType: CollectionElement]:
                 return Optional(k_v[][1])
         return Optional[ValueType](None)
 
-    fn __setitem__(inout self, key: KeyType, value: ValueType):
+    fn __setitem__(mut self, key: KeyType, value: ValueType):
         for k_v in self._data:
             if k_v[][0] == key:
                 k_v[][1] = value
@@ -57,7 +57,7 @@ struct SimdDict[keyDType: DType, ValueType: CollectionElement, size: Int]:
     var _keys: SIMD[keyDType, size]
     var _size: Int
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self._values = InlineArray[ValueType, size](unsafe_uninitialized=True)
         self._keys = SIMD[keyDType, size]()
         self._size = 0
@@ -80,7 +80,7 @@ struct SimdDict[keyDType: DType, ValueType: CollectionElement, size: Int]:
                 return Optional(self._values[i])
         return Optional[ValueType](None)
 
-    fn __setitem__(inout self, key: Self.KeyType, value: ValueType) raises:
+    fn __setitem__(mut self, key: Self.KeyType, value: ValueType) raises:
         for i in range(self._size):
             if self._keys[i] == key:
                 self._values[i] = value

--- a/src/types.mojo
+++ b/src/types.mojo
@@ -18,13 +18,13 @@ trait TrivialIntable(
     In the end, this trait should be one of UInt8, UInt16, UInt32, UInt64, etc.
     """
 
-    fn __init__(inout self, value: Int):
+    fn __init__(mut self, value: Int):
         ...
 
-    fn __init__(inout self, value: UInt):
+    fn __init__(mut self, value: UInt):
         ...
 
-    fn __iadd__(inout self: Self, rhs: Self):
+    fn __iadd__(mut self: Self, rhs: Self):
         ...
 
 

--- a/src/world.mojo
+++ b/src/world.mojo
@@ -104,7 +104,7 @@ struct World[*component_types: ComponentType]:
         *component_types
     ]  # Component manager.
 
-    fn __init__(inout self) raises:
+    fn __init__(mut self) raises:
         """
         Creates a new [World].
         """
@@ -136,7 +136,7 @@ struct World[*component_types: ComponentType]:
     @always_inline
     fn _get_archetype_index[
         size: Int
-    ](inout self, components: InlineArray[ComponentInfo, size],) -> Int:
+    ](mut self, components: InlineArray[ComponentInfo, size],) -> Int:
         """Returns the archetype list index of the archetype differing from
         the archetype at the start node by the given indices.
 
@@ -172,7 +172,7 @@ struct World[*component_types: ComponentType]:
     fn _get_archetype_index[
         size: Int
     ](
-        inout self,
+        mut self,
         components: InlineArray[Self.Id, size],
         start_node_index: Int = 0,
     ) -> Int:
@@ -211,7 +211,7 @@ struct World[*component_types: ComponentType]:
         return archetype_index
 
     @always_inline
-    fn new_entity(inout self) raises -> Entity as entity:
+    fn new_entity(mut self, out entity: Entity) raises:
         """Returns a new or recycled [Entity].
 
         Do not use during [Query] iteration!
@@ -227,7 +227,7 @@ struct World[*component_types: ComponentType]:
 
     fn new_entity[
         *Ts: ComponentType
-    ](inout self, *components: *Ts) raises -> Entity as entity:
+    ](mut self, *components: *Ts, out entity: Entity) raises:
         """Returns a new or recycled [Entity].
 
         The given component types are added to the entity.
@@ -283,12 +283,13 @@ struct World[*component_types: ComponentType]:
 
     @always_inline
     fn get_entities(
-        inout self,
-    ) raises -> _EntityIterator[
-        __origin_of(self._archetypes),
-        __origin_of(self._locks),
-        *component_types,
-    ]:
+        mut self,
+        out iterator: _EntityIterator[
+            __origin_of(self._archetypes),
+            __origin_of(self._locks),
+            *component_types,
+        ],
+    ) raises:
         """
         Returns an iterator with accessors to all entities with the given components.
 
@@ -298,7 +299,7 @@ struct World[*component_types: ComponentType]:
         Raises:
             Error: If the world is locked.
         """
-        return _EntityIterator(
+        iterator = _EntityIterator(
             self._component_manager,
             Pointer.address_of(self._archetypes),
             Pointer.address_of(self._locks),
@@ -308,11 +309,14 @@ struct World[*component_types: ComponentType]:
     @always_inline
     fn get_entities[
         *Ts: ComponentType
-    ](inout self) raises -> _EntityIterator[
-        __origin_of(self._archetypes),
-        __origin_of(self._locks),
-        *component_types,
-    ]:
+    ](
+        mut self,
+        out iterator: _EntityIterator[
+            __origin_of(self._archetypes),
+            __origin_of(self._locks),
+            *component_types,
+        ],
+    ) raises:
         """
         Returns an iterator with accessors to all entities with the given components.
 
@@ -322,7 +326,7 @@ struct World[*component_types: ComponentType]:
         Returns:
             An iterator with accessors to all entities with the given components.
         """
-        return _EntityIterator(
+        iterator = _EntityIterator(
             self._component_manager,
             Pointer.address_of(self._archetypes),
             Pointer.address_of(self._locks),
@@ -331,7 +335,7 @@ struct World[*component_types: ComponentType]:
 
     fn set[
         T: ComponentType
-    ](inout self, entity: Entity, owned component: T) raises:
+    ](mut self, entity: Entity, owned component: T) raises:
         """
         Overwrites a component for an [Entity], using the given content.
 
@@ -354,7 +358,7 @@ struct World[*component_types: ComponentType]:
 
     fn set[
         *Ts: ComponentType
-    ](inout self, entity: Entity, owned *components: *Ts) raises:
+    ](mut self, entity: Entity, owned *components: *Ts) raises:
         """
         Overwrites a component for an [Entity], using the given content.
 
@@ -383,7 +387,7 @@ struct World[*component_types: ComponentType]:
 
     fn get[
         T: ComponentType
-    ](inout self, entity: Entity) raises -> ref [self._archetypes[0]] T:
+    ](mut self, entity: Entity) raises -> ref [self._archetypes[0]] T:
         """Returns a reference to the given component of an [Entity].
 
         Raises:
@@ -404,7 +408,7 @@ struct World[*component_types: ComponentType]:
     @always_inline
     fn get_ptr[
         T: ComponentType
-    ](inout self, entity: Entity) raises -> Pointer[
+    ](mut self, entity: Entity) raises -> Pointer[
         T, __origin_of(self._archetypes[0])
     ]:
         """Returns a pointer to the given component of the Entity.
@@ -442,7 +446,7 @@ struct World[*component_types: ComponentType]:
         if not self._entity_pool.is_alive(entity):
             raise Error("The considered entity does not exist anymore.")
 
-    fn remove_entity(inout self, entity: Entity) raises:
+    fn remove_entity(mut self, entity: Entity) raises:
         """
         RemoveEntity removes an [Entity], making it eligible for recycling.
 
@@ -555,7 +559,7 @@ struct World[*component_types: ComponentType]:
 
     fn add[
         *Ts: ComponentType
-    ](inout self, entity: Entity, *add_components: *Ts) raises:
+    ](mut self, entity: Entity, *add_components: *Ts) raises:
         """
         Adds components to an [Entity].
 
@@ -573,7 +577,7 @@ struct World[*component_types: ComponentType]:
         """
         self._remove_and_add(entity, add_components)
 
-    fn remove[*Ts: ComponentType](inout self, entity: Entity) raises:
+    fn remove[*Ts: ComponentType](mut self, entity: Entity) raises:
         """
         Removes components from an [Entity].
 
@@ -595,7 +599,7 @@ struct World[*component_types: ComponentType]:
     @always_inline
     fn remove_and[
         *Ts: ComponentType
-    ](inout self) -> _Adder[
+    ](mut self) -> _Adder[
         __origin_of(self),
         VariadicPack[MutableAnyOrigin, ComponentType, *Ts].__len__(),
         *component_types,
@@ -621,7 +625,7 @@ struct World[*component_types: ComponentType]:
     fn _remove_and_add[
         *Ts: ComponentType, rem_size: Int = 0
     ](
-        inout self,
+        mut self,
         entity: Entity,
         *add_components: *Ts,
         remove_ids: Optional[InlineArray[Self.Id, rem_size]] = None,
@@ -650,7 +654,7 @@ struct World[*component_types: ComponentType]:
     fn _remove_and_add[
         *Ts: ComponentType, rem_size: Int = 0
     ](
-        inout self,
+        mut self,
         entity: Entity,
         add_components: VariadicPack[_, ComponentType, *Ts],
         remove_ids: Optional[InlineArray[Self.Id, rem_size]] = None,
@@ -1137,7 +1141,7 @@ struct World[*component_types: ComponentType]:
     #     return arch, startIdx
 
     @always_inline
-    fn _create_entity(inout self, archetype_index: Int) -> Entity as entity:
+    fn _create_entity(mut self, archetype_index: Int, out entity: Entity):
         """
         Creates an Entity and adds it to the given archetype.
         """
@@ -1151,7 +1155,7 @@ struct World[*component_types: ComponentType]:
     @always_inline
     fn _create_entities[
         element_origin: MutableOrigin
-    ](inout self, archetype_index: Int, count: Int):
+    ](mut self, archetype_index: Int, count: Int):
         """
         Creates multiple Entities and adds them to the given archetype.
         """
@@ -1373,13 +1377,13 @@ struct World[*component_types: ComponentType]:
 
     #     return arch, startIdx
 
-    fn _lock(inout self) raises -> UInt8:
+    fn _lock(mut self) raises -> UInt8:
         """
         Locks the world and gets the lock bit for later unlocking.
         """
         return self._locks.lock()
 
-    fn _unlock(inout self, lock: UInt8) raises:
+    fn _unlock(mut self, lock: UInt8) raises:
         """
         Unlocks the given lock bit.
         """

--- a/src/world_benchmark.mojo
+++ b/src/world_benchmark.mojo
@@ -6,7 +6,7 @@ from component import ComponentType, ComponentInfo
 from test_utils import *
 
 
-fn benchmark_new_entity_1_000_000(inout bencher: Bencher) raises capturing:
+fn benchmark_new_entity_1_000_000(mut bencher: Bencher) raises capturing:
     @always_inline
     @parameter
     fn bench_fn() capturing raises:
@@ -18,7 +18,7 @@ fn benchmark_new_entity_1_000_000(inout bencher: Bencher) raises capturing:
 
 
 fn benchmark_new_entity_1_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     pos = Position(1.0, 2.0)
 
@@ -39,7 +39,7 @@ fn prevent_inlining_new_entity_1_comp() raises:
 
 
 fn benchmark_new_entity_5_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     c1 = FlexibleComponent[1](1.0, 2.0)
     c2 = FlexibleComponent[2](1.0, 2.0)
@@ -79,7 +79,7 @@ fn prevent_inlining_new_entity_5_comp() raises:
     _ = world.new_entity(c1, c2, c3, c4, c5)
 
 
-fn benchmark_get_1_000_000(inout bencher: Bencher) raises capturing:
+fn benchmark_get_1_000_000(mut bencher: Bencher) raises capturing:
     pos = Position(1.0, 2.0)
     vel = Velocity(0.1, 0.2)
 
@@ -102,7 +102,7 @@ fn prevent_inlining_get() raises:
     keep(world.get[Position](entity).x)
 
 
-fn benchmark_get_ptr_1_000_000(inout bencher: Bencher) raises capturing:
+fn benchmark_get_ptr_1_000_000(mut bencher: Bencher) raises capturing:
     pos = Position(1.0, 2.0)
     vel = Velocity(0.1, 0.2)
 
@@ -125,7 +125,7 @@ fn prevent_inlining_get_ptr() raises:
     keep(world.get_ptr[Position](entity)[].x)
 
 
-fn benchmark_set_1_comp_1_000_000(inout bencher: Bencher) raises capturing:
+fn benchmark_set_1_comp_1_000_000(mut bencher: Bencher) raises capturing:
     pos = Position(1.0, 2.0)
     pos2 = Position(2.0, 2.0)
     vel = Velocity(0.1, 0.2)
@@ -153,7 +153,7 @@ fn prevent_inlining_set_1_comp() raises:
 
 
 fn benchmark_set_5_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     c1 = FlexibleComponent[1](1.0, 2.0)
     c2 = FlexibleComponent[2](1.0, 2.0)
@@ -211,7 +211,7 @@ fn prevent_inlining_set_5_comp() raises:
 
 
 fn benchmark_add_remove_entity_1_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     pos = Position(1.0, 2.0)
 
@@ -238,7 +238,7 @@ fn prevent_inlining_add_remove_entity_1_comp() raises:
 
 
 fn benchmark_add_remove_entity_5_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     c1 = FlexibleComponent[1](1.0, 2.0)
     c2 = FlexibleComponent[2](1.0, 2.0)
@@ -286,7 +286,7 @@ fn prevent_inlining_add_remove_entity_5_comp() raises:
     world.remove_entity(entity)
 
 
-fn benchmark_has_1_000_000(inout bencher: Bencher) raises capturing:
+fn benchmark_has_1_000_000(mut bencher: Bencher) raises capturing:
     pos = Position(1.0, 2.0)
     vel = Velocity(0.1, 0.2)
 
@@ -301,7 +301,7 @@ fn benchmark_has_1_000_000(inout bencher: Bencher) raises capturing:
     bencher.iter[bench_fn]()
 
 
-fn benchmark_is_alive_1_000_000(inout bencher: Bencher) raises capturing:
+fn benchmark_is_alive_1_000_000(mut bencher: Bencher) raises capturing:
     pos = Position(1.0, 2.0)
     vel = Velocity(0.1, 0.2)
 
@@ -317,7 +317,7 @@ fn benchmark_is_alive_1_000_000(inout bencher: Bencher) raises capturing:
 
 
 fn benchmark_add_remove_1_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     pos = Position(1.0, 2.0)
     vel = Velocity(0.1, 0.2)
@@ -344,7 +344,7 @@ fn prevent_inlining_add_remove_1_comp() raises:
 
 
 fn benchmark_add_remove_5_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     c1 = FlexibleComponent[1](1.0, 2.0)
     c2 = FlexibleComponent[2](1.0, 2.0)
@@ -406,7 +406,7 @@ fn prevent_inlining_add_remove_5_comp() raises:
 
 
 fn benchmark_exchange_1_comp_1_000_000(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     @always_inline
     @parameter
@@ -430,7 +430,7 @@ fn benchmark_exchange_1_comp_1_000_000(
 
 
 fn benchmark_exchange_1_comp_1_000_000_extra(
-    inout bencher: Bencher,
+    mut bencher: Bencher,
 ) raises capturing:
     pos = Position(1.0, 2.0)
 
@@ -460,7 +460,7 @@ fn run_all_world_benchmarks() raises:
     bench.dump_report()
 
 
-fn run_all_world_benchmarks(inout bench: Bench) raises:
+fn run_all_world_benchmarks(mut bench: Bench) raises:
     bench.bench_function[benchmark_new_entity_1_000_000](
         BenchId("10^6 * new_entity")
     )


### PR DESCRIPTION
The `-> Int as x` syntax is deprecated
The inout keyword is replaced with mut