### PR TITLE
More compact API docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  MODO_VERSION: 6f7c9c3 # 0.4.0
+  MODO_VERSION: 0.6.0
   HUGO_VERSION: 0.140.2
 
 jobs:
@@ -27,24 +27,24 @@ jobs:
           source /home/runner/.bash_profile
           magic install --locked
         
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.23.x'
-      - name: Clone Modo
-        run: |
-          git clone https://github.com/mlange-42/modo.git
-          cd modo
-          git checkout ${{env.MODO_VERSION}}
-      - name: Build Modo
-        run: |
-          cd modo
-          go get .
-          go build .
-          
-      #- name: Download Modo
+      #- name: Setup Go
+      #  uses: actions/setup-go@v3
+      #  with:
+      #    go-version: '1.23.x'
+      #- name: Clone Modo
       #  run: |
-      #    curl -sSL https://github.com/mlange-42/modo/releases/download/v${{env.MODO_VERSION}}/modo-v${{env.MODO_VERSION}}-linux-amd64.tar.gz | tar -xz
+      #    git clone https://github.com/mlange-42/modo.git
+      #    cd modo
+      #    git checkout ${{env.MODO_VERSION}}
+      #- name: Build Modo
+      #  run: |
+      #    cd modo
+      #    go get .
+      #    go build .
+          
+      - name: Download Modo
+        run: |
+          curl -sSL https://github.com/mlange-42/modo/releases/download/v${{env.MODO_VERSION}}/modo-v${{env.MODO_VERSION}}-linux-amd64.tar.gz | tar -xz
       
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
           magic run mojo doc -o larecs.json src/larecs
       - name: Create Markdown
         run: |
-          ./modo/modo docs/content -i larecs.json --exports --short-links --format=hugo --templates=docs/modo
+          ./modo docs/content -i larecs.json --exports --short-links --format=hugo --templates=docs/modo
       - name: Run hugo
         run: |
           hugo -s docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
           magic run mojo doc -o larecs.json src/larecs
       - name: Create Markdown
         run: |
-          ./modo/modo docs/content -i larecs.json --format=hugo --short-links --exports
+          ./modo/modo docs/content -i larecs.json --exports --short-links --format=hugo --templates=docs/modo
       - name: Run hugo
         run: |
           hugo -s docs

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -28,3 +28,18 @@
 .content :where(h1, h2, h3, h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) code {
   font-size: 100%;
 }
+
+/* smaller headings */
+.content :where(h1):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-size: 2.0rem;
+}
+
+.content :where(h2):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-size: 1.66rem;
+  margin-top: 2.0rem;
+}
+
+.content :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  font-size: 1.4rem;
+  margin-top: 1.66rem;
+}

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -1,0 +1,30 @@
+/* paragraph line height */
+.content :where(p):not(:where([class~=not-prose], [class~=not-prose] *)) {
+  margin-top: 0.66rem;
+  line-height: 1.33rem;
+}
+
+/* list line height */
+.content :where(ul):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: 0.66rem;
+}
+
+.content :where(ul):not(:where([class~="not-prose"], [class~="not-prose"] *)) li {
+  margin-top: 0.0rem;
+  margin-bottom: 0.0rem;
+}
+
+/* code blocks */
+.hx-mt-6 {
+  margin-top: 0.66rem;
+}
+
+.hextra-code-block pre {
+  text-wrap: auto;
+  font-size: 1.0em;
+}
+
+/* code in headings */
+.content :where(h1, h2, h3, h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) code {
+  font-size: 100%;
+}

--- a/docs/modo/hugo_front_matter.md
+++ b/docs/modo/hugo_front_matter.md
@@ -1,0 +1,4 @@
+---
+type: docs
+title: {{if and (eq .Name "larecs") (eq .Kind "package")}}API docs{{else}}{{.Name}}{{end}}
+---


### PR DESCRIPTION
Tries to improve clarity of the docs, and to reduce scrolling.

CSS:

* Globally reduced line height.
* Decrease spacing above paragraphs, list items and code blocks.
* Decrease font siz and padding above headings.
* Word wrap in code blocks, particularly for long signatures.
* Slightly increased font size in code blocks.
* Code in headings is 100% font size, not 90%.

Modo template:

* Replace `larecs` in navigation and page title by `API docs`

before:

![grafik](https://github.com/user-attachments/assets/ff884133-a2ca-43fb-be89-fd7f6dd3dcf2)

after:

![grafik](https://github.com/user-attachments/assets/85b8f3e1-7a92-44c9-869c-74efbcf3f3de)

before:

![grafik](https://github.com/user-attachments/assets/b5f526ad-a693-41f5-b695-17035a4d55d1)

after:

![grafik](https://github.com/user-attachments/assets/297538c9-d593-40b7-8df7-454e404edd0f)
