### PR TITLE
Collapse function and method docs

### DIFF
--- a/docs/layouts/shortcodes/expand-all.html
+++ b/docs/layouts/shortcodes/expand-all.html
@@ -15,5 +15,5 @@ function collapseAll() {
     }
 }
 </script>
-<a class="" onclick="expandAll()" style="cursor:pointer; text-decoration: none;" title="Expand all">➕</a>&nbsp;
-<a class="" onclick="collapseAll()" style="cursor:pointer; text-decoration: none;" title="Collapse all">➖</a>
+<a class="" onclick="expandAll()" style="cursor:pointer;">Expand&nbsp;all</a>&nbsp;&nbsp;
+<a class="" onclick="collapseAll()" style="cursor:pointer;">Collapse&nbsp;all</a>

--- a/docs/layouts/shortcodes/expand-all.html
+++ b/docs/layouts/shortcodes/expand-all.html
@@ -1,0 +1,19 @@
+<script lang="JS">
+function expandAll() {
+    var inputs = document.getElementsByTagName('details');
+
+    for(var i = 0; i < inputs.length; i++) {
+        inputs[i].open = true;
+    }
+}
+
+function collapseAll() {
+    var inputs = document.getElementsByTagName('details');
+
+    for(var i = 0; i < inputs.length; i++) {
+        inputs[i].open = false;
+    }
+}
+</script>
+<a class="" onclick="expandAll()" style="cursor:pointer; text-decoration: none;" title="Expand all">➕</a>&nbsp;
+<a class="" onclick="collapseAll()" style="cursor:pointer; text-decoration: none;" title="Collapse all">➖</a>

--- a/docs/layouts/shortcodes/html.html
+++ b/docs/layouts/shortcodes/html.html
@@ -1,0 +1,2 @@
+<!-- raw html -->
+{{.Inner}}

--- a/docs/modo/function.md
+++ b/docs/modo/function.md
@@ -1,0 +1,13 @@
+Mojo function
+
+# `{{.Name}}`
+
+{{`{{<expand-all>}}`}}
+
+{{if .Overloads -}}
+{{range .Overloads -}}
+{{template "overload" . -}}
+{{end -}}
+{{else -}}
+{{template "overload" . -}}
+{{- end}}

--- a/docs/modo/methods.md
+++ b/docs/modo/methods.md
@@ -1,0 +1,10 @@
+{{define "methods" -}}
+{{if .Functions}}## Methods
+
+{{`{{<expand-all>}}`}}
+
+{{range .Functions -}}
+{{template "method" . -}}
+{{end}}
+{{end}}
+{{- end}}

--- a/docs/modo/overload.md
+++ b/docs/modo/overload.md
@@ -1,0 +1,14 @@
+{{define "overload" -}}
+```mojo
+{{.Signature}}
+```
+
+{{`{{<html>}}`}}<details>
+<summary>{{`{{</html>}}`}}{{template "summary" . -}}{{`{{<html>}}`}}</summary>{{`{{</html>}}`}}
+{{template "description" . -}}
+{{template "func_parameters" . -}}
+{{template "func_args" . -}}
+{{template "func_returns" . -}}
+{{template "func_raises" . -}}
+{{`{{<html>}}`}}</details>{{`{{</html>}}`}}
+{{end}}


### PR DESCRIPTION
Makes methods listings more concise by putting exerything bis the summary into collapsible `details` tags.

Uses Modo's template overwrite feature to add the `details` tag. Requires a Hugo shortcode `html` to allow for raw HTML in Markdown.

![grafik](https://github.com/user-attachments/assets/7ae08a7d-093e-40df-a5c3-be5194d735b1)
