### PR TITLE
Enable Mojo highlighting via Hugo fork

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 env:
-  MODO_VERSION: 8223cd9
-  HUGO_VERSION: 0.140.2
+  MODO_VERSION: 0.9.0
+  HUGO_VERSION: mojo-lexer # 0.140.2
 
 jobs:
 
@@ -27,34 +27,45 @@ jobs:
           source /home/runner/.bash_profile
           magic install --locked
         
-      # Install Modo from commit hash
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: '1.23.x'
-      - name: Clone Modo
-        run: |
-          git clone https://github.com/mlange-42/modo.git
-          cd modo
-          git checkout ${{env.MODO_VERSION}}
-      - name: Build Modo
-        run: |
-          cd modo
-          go get .
-          go build .
+
+      # Install Modo from commit hash
+      #- name: Clone Modo
+      #  run: |
+      #    git clone https://github.com/mlange-42/modo.git
+      #    cd modo
+      #    git checkout ${{env.MODO_VERSION}}
+      #- name: Build Modo
+      #  run: |
+      #    cd modo
+      #    go get .
+      #    go build .
       
       # Download Modo release
-      #- name: Download Modo
-      #  run: |
-      #    mkdir modo/
-      #    curl -sSL https://github.com/mlange-42/modo/releases/download/v${{env.MODO_VERSION}}/modo-v${{env.MODO_VERSION}}-linux-amd64.tar.gz | tar -xz -C modo/
-      
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: '${{env.HUGO_VERSION}}'
-          extended: true
-      
+      - name: Download Modo
+        run: |
+          mkdir modo/
+          curl -sSL https://github.com/mlange-42/modo/releases/download/v${{env.MODO_VERSION}}/modo-v${{env.MODO_VERSION}}-linux-amd64.tar.gz | tar -xz -C modo/
+
+      #- name: Setup Hugo
+      #  uses: peaceiris/actions-hugo@v3
+      #  with:
+      #    hugo-version: '${{env.HUGO_VERSION}}'
+      #    extended: true
+
+      - name: Clone Hugo
+        run: |
+          git clone https://github.com/mlange-42/hugo.git
+          cd hugo
+          git checkout ${{env.HUGO_VERSION}}
+      - name: Install Hugo
+        run: |
+          cd hugo
+          go install .
+
       - name: Run Modo # Includes 'mojo doc' and 'mojo test'
         run: |
           source /home/runner/.bash_profile

--- a/docs/modo/signature.md
+++ b/docs/modo/signature.md
@@ -1,5 +1,0 @@
-{{define "signature" -}}
-```python
-{{if .Signature}}{{.Signature}}{{else}}{{.Name}}{{end}}
-```
-{{- end}}

--- a/docs/modo/signature_struct.md
+++ b/docs/modo/signature_struct.md
@@ -1,6 +1,0 @@
-{{define "signature_struct" -}}
-```python
-{{if .Convention}}@{{.Convention}}{{end}}
-{{if .Signature}}{{.Signature}}{{else}}{{.Name}}{{end}}
-```
-{{- end}}

--- a/src/larecs/__init__.mojo
+++ b/src/larecs/__init__.mojo
@@ -8,7 +8,7 @@ testing purposes.
 
 Example:
 
-```python {doctest="readme" global=true}
+```mojo {doctest="readme" global=true}
 # Import the package
 from larecs import World
 

--- a/src/larecs/world.mojo
+++ b/src/larecs/world.mojo
@@ -232,11 +232,11 @@ struct World[*component_types: ComponentType]:
 
         Example:
 
-        ```python {doctest="add_entity" global=true hide=true}
+        ```mojo {doctest="add_entity" global=true hide=true}
         from larecs import World
         ```
 
-        ```python {doctest="add_entity"}
+        ```mojo {doctest="add_entity"}
         world = World()
         e = world.add_entity()
         ```
@@ -263,7 +263,7 @@ struct World[*component_types: ComponentType]:
 
         Example:
 
-        ```python {doctest="add_entity_comps" global=true hide=true}
+        ```mojo {doctest="add_entity_comps" global=true hide=true}
         from larecs import World
 
         @value
@@ -277,7 +277,7 @@ struct World[*component_types: ComponentType]:
             var y: Float64
         ```
 
-        ```python {doctest="add_entity_comps"}
+        ```mojo {doctest="add_entity_comps"}
         world = World[Position, Velocity]()
         e = world.add_entity(
             Position(0, 0),


### PR DESCRIPTION
- installs a Hugo fork with Mojo lexer in the CI
- reverts all code blocks back to Mojo (except README)

![grafik](https://github.com/user-attachments/assets/984b7e4d-339b-46f9-9970-fddebdc40225)

![grafik](https://github.com/user-attachments/assets/9948d198-9a79-4c87-96a9-fc69317ff38e)



