### PR TITLE
Tweak features in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ It is based on the ECS [Arche](https://github.com/mlange-42/arche), implemented 
 ## Features
 
 - Clean and simple API
-- High performance due to Archetype-based architecture and extensive use of Mojo's compile-time programming tools
-- Support for SIMD computing via a [`vectorize`](https://docs.modular.com/mojo/stdlib/algorithm/functional/vectorize/)-like syntax
+- High performance due to archetypes and Mojo's compile-time programming
+- Support for SIMD via a [`vectorize`](https://docs.modular.com/mojo/stdlib/algorithm/functional/vectorize/)-like syntax
 - Compile-time checks thanks to usage of parameters
 - Native support for [resources](https://mlange-42.github.io/arche/guide/resources/)
 - Tested and benchmarked


### PR DESCRIPTION
I think the second feature was way too long. Each one should be concise, potentially with a link for details if you have more to tell.

The other changes are just a matter of taste.

Generally, a feature list on a README should not be longer than 7 items IMO. Ideally 5. (attention span of a gold fish etc). If there are more, summarize and link to details. Or make a short list and a long list.