### PR TITLE
Remove get_ptr in favour of references

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,12 @@ fn main() raises:
 
     # We can query entities with specific components
     for entity in world.query[Position, Velocity]():
-        # use get_ptr to get a pointer to a specific component
-        position = entity.get_ptr[Position]()
+        # Get references to specific components
+        ref position = entity.get[Position]()
+        ref velocity = entity.get[Velocity]()
 
-        # use get to get a reference / copy of a specific component
-        velocity = entity.get[Velocity]()
-
-        position[].x += velocity.x
-        position[].y += velocity.y
+        position.x += velocity.x
+        position.y += velocity.y
 ```
 
 

--- a/benchmark/plots/src/aos.mojo
+++ b/benchmark/plots/src/aos.mojo
@@ -228,10 +228,10 @@ fn benchmark[
     var start_ecs: Float64 = perf_counter_ns()
     for _ in range(rounds):
         for entity in w1.query[Position, Velocity]():
-            position = entity.get_ptr[Position]()
-            velocity = entity.get[Velocity]()
-            position[].x += velocity.x
-            position[].y += velocity.y
+            ref position = entity.get[Position]()
+            ref velocity = entity.get[Velocity]()
+            position.x += velocity.x
+            position.y += velocity.y
     dur_ecs = (perf_counter_ns() - start_ecs) / (entities * rounds)
 
     w2 = AosWorld[components_exp](entities)

--- a/benchmark/query_benchmark.mojo
+++ b/benchmark/query_benchmark.mojo
@@ -144,9 +144,6 @@ fn run_all_query_benchmarks(mut bench: Bench) raises:
     bench.bench_function[benchmark_query_2_comp_1_000_000](
         BenchId("10^6 * query & get 2 comp")
     )
-    bench.bench_function[benchmark_query_2_comp_ptr_1_000_000](
-        BenchId("10^6 * query & get ptr 2 comp")
-    )
     bench.bench_function[benchmark_query_5_comp_1_000_000](
         BenchId("10^6 * query & get 5 comp")
     )

--- a/benchmark/query_benchmark.mojo
+++ b/benchmark/query_benchmark.mojo
@@ -55,26 +55,6 @@ fn benchmark_query_2_comp_1_000_000(
     bencher.iter[bench_fn]()
 
 
-fn benchmark_query_2_comp_ptr_1_000_000(
-    mut bencher: Bencher,
-) raises capturing:
-    pos = Position(1.0, 2.0)
-    vel = Velocity(0.1, 0.2)
-
-    @always_inline
-    @parameter
-    fn bench_fn() capturing raises:
-        world = SmallWorld()
-        for _ in range(1000):
-            _ = world.add_entity(pos, vel)
-        for _ in range(1000):
-            for entity in world.query[Position, Velocity]():
-                keep(entity.get_ptr[Position]()[].x)
-                keep(entity.get_ptr[Velocity]()[].dx)
-
-    bencher.iter[bench_fn]()
-
-
 fn benchmark_query_5_comp_1_000_000(
     mut bencher: Bencher,
 ) raises capturing:

--- a/benchmark/world_benchmark.mojo
+++ b/benchmark/world_benchmark.mojo
@@ -140,29 +140,6 @@ fn prevent_inlining_get() raises:
     keep(world.get[Position](entity).x)
 
 
-fn benchmark_get_ptr_1_000_000(mut bencher: Bencher) raises capturing:
-    pos = Position(1.0, 2.0)
-    vel = Velocity(0.1, 0.2)
-
-    @always_inline
-    @parameter
-    fn bench_fn() capturing raises:
-        world = SmallWorld()
-        entity = world.add_entity(pos, vel)
-        for _ in range(1_000_000):
-            keep(world.get_ptr[Position](entity)[].x)
-
-    bencher.iter[bench_fn]()
-
-
-fn prevent_inlining_get_ptr() raises:
-    pos = Position(1.0, 2.0)
-    vel = Velocity(0.1, 0.2)
-    world = SmallWorld()
-    entity = world.add_entity(pos, vel)
-    keep(world.get_ptr[Position](entity)[].x)
-
-
 fn benchmark_set_1_comp_1_000_000(mut bencher: Bencher) raises capturing:
     pos = Position(1.0, 2.0)
     pos2 = Position(2.0, 2.0)
@@ -256,9 +233,9 @@ fn benchmark_apply_expexp_1_comp_100_000(
         @parameter
         fn operation_plus(accessor: MutableEntityAccessor) capturing:
             try:
-                pos2 = accessor.get_ptr[Position]()
-                pos2[].x = exp(1 - exp(pos2[].x))
-                pos2[].y = exp(1 - exp(pos2[].y))
+                ref pos2 = accessor.get[Position]()
+                pos2.x = exp(1 - exp(pos2.x))
+                pos2.y = exp(1 - exp(pos2.y))
             except:
                 pass
 
@@ -292,10 +269,10 @@ fn benchmark_apply_simd_expexp_1_comp_100_000(
             alias _store = store2[simd_width]
 
             try:
-                pos2 = accessor.get_ptr[Position]()
+                ref pos2 = accessor.get[Position]()
 
-                _store(pos2[].x, exp(1 - exp(_load(pos2[].x))))
-                _store(pos2[].y, exp(1 - exp(_load(pos2[].y))))
+                _store(pos2.x, exp(1 - exp(_load(pos2.x))))
+                _store(pos2.y, exp(1 - exp(_load(pos2.y))))
             except:
                 pass
 
@@ -629,7 +606,6 @@ fn run_all_world_benchmarks(mut bench: Bench) raises:
         benchmark_add_remove_entities_5_comp_1_000_batch_1_000
     ](BenchId("10^3 * add & remove entity (5 components) 1000 batch"))
     bench.bench_function[benchmark_get_1_000_000](BenchId("10^6 * get"))
-    bench.bench_function[benchmark_get_ptr_1_000_000](BenchId("10^6 * get_ptr"))
     bench.bench_function[benchmark_set_1_comp_1_000_000](
         BenchId("10^6 * set 1 component")
     )
@@ -664,7 +640,6 @@ fn run_all_world_benchmarks(mut bench: Bench) raises:
     prevent_inlining_add_entity_1_comp()
     prevent_inlining_add_entity_5_comp()
     prevent_inlining_get()
-    prevent_inlining_get_ptr()
     prevent_inlining_set_1_comp()
     prevent_inlining_set_5_comp()
     prevent_inlining_replace()

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,9 @@
 - Update the utilized Mojo version and adjust the code accordingly.
 - Remove the `TypeIdentifiable` trait, the `TypeId` struct, as well as the TypeMaps. 
   Instead, resources now use the built-in reflections module to identify types.
-- Remove `Resource.get_ptr`, since getting a reference is now sufficient if using the `ref` keyword.
+- Remove all `get_ptr` functions, since getting a reference is now sufficient if using the `ref` keyword.
+  This applies to entities as well as resources.
+
 
 ## [v0.2.0 (2025-05-14)](https://github.com/samufi/larecs/tree/v0.2.0)
 

--- a/docs/src/guide/changing_entities.md
+++ b/docs/src/guide/changing_entities.md
@@ -45,11 +45,11 @@ ref pos = world.get[Position](entity)
 
 # We can change the reference.
 pos.x = 5
-assert_equal(world.get[Position](entity).x == 5)
+assert_equal(world.get[Position](entity).x, 5)
 
 # We can also replace the component completely. 
 world.get[Position](entity) = Position(10, 0)
-assert_equal(world.get[Position](entity).x == 10)
+assert_equal(world.get[Position](entity).x, 10)
 ```
 
 Of course, accessing a component only works if the entity has

--- a/docs/src/guide/changing_entities.md
+++ b/docs/src/guide/changing_entities.md
@@ -12,11 +12,7 @@ existing components.
 
 The values of an entity's component can be 
 accessed and changed via the {{< api World.get get >}} 
-and {{< api World.get_ptr get_ptr >}}
-methods of world. Here, `get` returns a reference, 
-which becomes a copy of the component if stored in a local variable,
-and `get_ptr` returns a pointer, which can write into  
-the original memory even if stored locally.
+method of world. 
 
 ```mojo {doctest="guide_change_entities" global=true hide=true}
 from larecs import World
@@ -45,31 +41,15 @@ as follows:
 entity = world.add_entity(Position(0, 0))
 
 # Get a reference to the position;
-# storing this in a local variable makes it a copy
-pos = world.get[Position](entity)
+ref pos = world.get[Position](entity)
 
-# This does not change the entity's state!
-pos.x = 5 
-print(world.get[Position](entity).x == pos.x) # False
+# We can change the reference.
+pos.x = 5
+assert_equal(world.get[Position](entity).x == 5)
 
-# Changing the reference in-place works, though.
-world.get[Position](entity).x = 5
-
-# Similarly, replacing the component completely 
-# works as well.
-world.get[Position](entity) = Position(5, 0)
-```
-
-To access and change a component later in 
-the current method, we use a pointer:
-
-```mojo {doctest="guide_change_entities"}
-# Get a pointer to the Position component
-pos_ptr = world.get_ptr[Position](entity)
-
-# Now, changing the value via the local pointer variable works.
-pos_ptr[].x = 10 # Use the `[]` operator to dereference the pointer
-print(world.get[Position](entity).x == 10) # True
+# We can also replace the component completely. 
+world.get[Position](entity) = Position(10, 0)
+assert_equal(world.get[Position](entity).x == 10)
 ```
 
 Of course, accessing a component only works if the entity has

--- a/docs/src/guide/queries_iteration.md
+++ b/docs/src/guide/queries_iteration.md
@@ -56,10 +56,10 @@ print(len(query)) # "2"
 
 # Now let us iterate over the queried entities
 for entity in query:
-    pos = entity.get_ptr[Position]()
+    ref pos = entity.get[Position]()
     print(
         "Entity at position: (" 
-        + String(pos[].x) + ", " + String(pos[].y) + ")"
+        + String(pos.x) + ", " + String(pos.y) + ")"
     )
 ```
 
@@ -105,17 +105,17 @@ methods for this, making the code more efficient.
 
 ```mojo {doctest="guide_queries_iteration"}
 for entity in world.query[Position]():
-    pos = entity.get_ptr[Position]()
+    ref pos = entity.get[Position]()
     print(
         "Entity at position: (" 
-        + String(pos[].x) + ", " + String(pos[].y) + ")"
+        + String(pos.x) + ", " + String(pos.y) + ")"
     )
     if entity.has[Velocity]():
-        vel = entity.get_ptr[Velocity]()
+        ref vel = entity.get[Velocity]()
         # Also print the velocity
         print(
             " - with velocity (" 
-            + String(vel[].dx) + ", " + String(vel[].dy) + ")"
+            + String(vel.dx) + ", " + String(vel.dy) + ")"
         )
 ```
 
@@ -208,10 +208,10 @@ with a `Position` and a `Velocity` component, we can do this as follows:
 # Define the move function
 fn move(entity: MutableEntityAccessor) capturing:
     try:
-        move_pos = entity.get_ptr[Position]()
-        move_vel = entity.get_ptr[Velocity]()
-        move_pos[].x += move_vel[].dx
-        move_pos[].y += move_vel[].dy
+        ref move_pos = entity.get[Position]()
+        ref move_vel = entity.get[Velocity]()
+        move_pos.x += move_vel.dx
+        move_pos.y += move_vel.dy
     except:
         # We could do proper error handling here
         # but for now, we just ignore the error

--- a/docs/src/guide/systems_scheduler.md
+++ b/docs/src/guide/systems_scheduler.md
@@ -108,8 +108,8 @@ struct Logger[interval: Int](System):
 
     fn _print_positions(self, mut world: World) raises:
         for entity in world.query[Position, Velocity]():
-            pos = entity.get_ptr[Position]()
-            print("(", pos[].x, ",", pos[].y, ")")
+            ref pos = entity.get[Position]()
+            print("(", pos.x, ",", pos.y, ")")
 
     # This is executed once at the beginning
     fn initialize(mut self, mut world: World) raises:

--- a/docs/src/guide/vectorization.md
+++ b/docs/src/guide/vectorization.md
@@ -116,13 +116,13 @@ updated signature of the function reads as follows:
 fn move[simd_width: Int](entity: MutableEntityAccessor) capturing:
 ```
 
-Again we start implementing `move` by obtaining references 
+Again we start implementing `move` by obtaining pointers 
 to the `Position` and `Velocity` components. 
 
 ```mojo {doctest="guide_simd_apply"}
     try:
-        ref pos = entity.get[Position]()
-        ref vel = entity.get[Velocity]()
+        pos = Pointer(to=entity.get[Position]())
+        vel = Pointer(to=entity.get[Velocity]())
     except:
         return
 ```
@@ -142,10 +142,10 @@ us to specify the stride manually.
 Hence, we need `UnsafePointer`s to the components.
 
 ```mojo {doctest="guide_simd_apply"}
-    pos_x_ptr = UnsafePointer(to=pos.x)
-    pos_y_ptr = UnsafePointer(to=pos.y)
-    vel_x_ptr = UnsafePointer(to=vel.dx)
-    vel_y_ptr = UnsafePointer(to=vel.dy)
+    pos_x_ptr = UnsafePointer(to=pos[].x)
+    pos_y_ptr = UnsafePointer(to=pos[].y)
+    vel_x_ptr = UnsafePointer(to=vel[].dx)
+    vel_y_ptr = UnsafePointer(to=vel[].dy)
 ```
 
 Now we can load `simd_width` values of `x` and `y`

--- a/docs/src/guide/vectorization.md
+++ b/docs/src/guide/vectorization.md
@@ -116,13 +116,13 @@ updated signature of the function reads as follows:
 fn move[simd_width: Int](entity: MutableEntityAccessor) capturing:
 ```
 
-Again we start implementing `move` by obtaining pointers 
+Again we start implementing `move` by obtaining references 
 to the `Position` and `Velocity` components. 
 
 ```mojo {doctest="guide_simd_apply"}
     try:
-        pos = entity.get_ptr[Position]()
-        vel = entity.get_ptr[Velocity]()
+        ref pos = entity.get[Position]()
+        ref vel = entity.get[Velocity]()
     except:
         return
 ```
@@ -142,10 +142,10 @@ us to specify the stride manually.
 Hence, we need `UnsafePointer`s to the components.
 
 ```mojo {doctest="guide_simd_apply"}
-    pos_x_ptr = UnsafePointer(to=pos[].x)
-    pos_y_ptr = UnsafePointer(to=pos[].y)
-    vel_x_ptr = UnsafePointer(to=vel[].dx)
-    vel_y_ptr = UnsafePointer(to=vel[].dy)
+    pos_x_ptr = UnsafePointer(to=pos.x)
+    pos_y_ptr = UnsafePointer(to=pos.y)
+    vel_x_ptr = UnsafePointer(to=vel.dx)
+    vel_y_ptr = UnsafePointer(to=vel.dy)
 ```
 
 Now we can load `simd_width` values of `x` and `y`

--- a/examples/satellites/systems.mojo
+++ b/examples/satellites/systems.mojo
@@ -9,11 +9,11 @@ fn move(mut world: World) raises:
     ref parameters = world.resources.get[Parameters]()
 
     for entity in world.query[Position, Velocity]():
-        position = entity.get_ptr[Position]()
-        velocity = entity.get_ptr[Velocity]()
+        ref position = entity.get[Position]()
+        ref velocity = entity.get[Velocity]()
 
-        position[].x += velocity[].x * parameters.dt
-        position[].y += velocity[].y * parameters.dt
+        position.x += velocity.x * parameters.dt
+        position.y += velocity.y * parameters.dt
 
 
 fn accelerate(mut world: World) raises:
@@ -21,13 +21,13 @@ fn accelerate(mut world: World) raises:
     constant = -GRAVITATIONAL_CONSTANT * parameters.mass * parameters.dt
 
     for entity in world.query[Position, Velocity]():
-        position = entity.get[Position]()
-        velocity = entity.get_ptr[Velocity]()
+        ref position = entity.get[Position]()
+        ref velocity = entity.get[Velocity]()
 
         multiplier = constant * (position.x**2 + position.y**2) ** (-1.5)
 
-        velocity[].x += position.x * multiplier
-        velocity[].y += position.y * multiplier
+        velocity.x += position.x * multiplier
+        velocity.y += position.y * multiplier
 
 
 fn get_random_position() -> Position:

--- a/src/larecs/__init__.mojo
+++ b/src/larecs/__init__.mojo
@@ -50,14 +50,12 @@ fn main() raises:
 
     # We can query entities with specific components
     for entity in world.query[Position, Velocity]():
-        # use get_ptr to get a pointer to a specific component
-        position = entity.get_ptr[Position]()
+        # get references to components
+        ref position = entity.get[Position]()
+        ref velocity = entity.get[Velocity]()
 
-        # use get to get a reference / copy of a specific component
-        velocity = entity.get[Velocity]()
-
-        position[].x += velocity.x
-        position[].y += velocity.y
+        position.x += velocity.x
+        position.y += velocity.y
 ```
 
 ```mojo {doctest="readme" hide=true}

--- a/src/larecs/archetype.mojo
+++ b/src/larecs/archetype.mojo
@@ -83,25 +83,6 @@ struct EntityAccessor[
         )
 
     @always_inline
-    fn get_ptr[
-        T: ComponentType
-    ](ref self) raises -> Pointer[T, __origin_of(self._archetype[]._data)]:
-        """Returns a pointer to the given component of the Entity.
-
-        Parameters:
-            T: The type of the component.
-
-        Returns:
-            A pointer to the component of the entity.
-
-        Raises:
-            Error: If the entity does not have the component.
-        """
-        return self._archetype[].get_component_ptr[T=T](
-            self._index_in_archetype,
-        )
-
-    @always_inline
     fn set[
         *Ts: ComponentType
     ](
@@ -569,36 +550,6 @@ struct Archetype[
             A pointer to the component.
         """
         return self._data[id] + idx * self._item_sizes[id]
-
-    @always_inline
-    fn get_component_ptr[
-        IndexType: Indexer, //,
-        *,
-        T: ComponentType,
-        assert_has_component: Bool = True,
-    ](ref self, idx: IndexType) raises -> Pointer[T, __origin_of(self._data)]:
-        """Returns the component with the given id at the given index.
-
-        Args:
-            idx:    The index of the entity.
-
-        Parameters:
-            IndexType: The type of the index.
-            T: The type of the component.
-            assert_has_component: Whether to assert that the archetype
-                    contains the component.
-
-        Raises:
-            Error:  If assert_has_component and the archetype does not contain the component.
-
-        Returns:
-            A pointer to the component.
-        """
-        return Pointer[T, __origin_of(self._data)](
-            to=self.get_component[
-                T=T, assert_has_component=assert_has_component
-            ](idx)
-        )
 
     @always_inline
     fn get_component[

--- a/src/larecs/query.mojo
+++ b/src/larecs/query.mojo
@@ -27,8 +27,8 @@ struct Query[
     _ = world.add_entity(Float64(1.0), 3)
 
     for entity in world.query[Float64, Int]():
-        f = entity.get_ptr[Float64]()
-        f[] += 1
+        ref f = entity.get[Float64]()
+        f += 1
     ```
 
     Parameters:
@@ -119,8 +119,8 @@ struct Query[
         _ = world.add_entity(Float64(1.0), 3)
 
         for entity in world.query[Float64, Int]().without[Float32]():
-            f = entity.get_ptr[Float64]()
-            f[] += 1
+            ref f = entity.get[Float64]()
+            f += 1
         ```
 
         Parameters:
@@ -150,8 +150,8 @@ struct Query[
         _ = world.add_entity(Float64(1.0), 3)
 
         for entity in world.query[Float64, Int]().exclusive():
-            f = entity.get_ptr[Float64]()
-            f[] += 1
+            ref f = entity.get[Float64]()
+            f += 1
         ```
 
         Returns:

--- a/src/larecs/resource.mojo
+++ b/src/larecs/resource.mojo
@@ -182,7 +182,7 @@ struct Resources(ExplicitlyCopyable, Movable):
     fn get[
         T: ResourceType
     ](mut self) raises -> ref [
-        __origin_of(self._storage._find_ref("").unsafe_get_ptr[T]()[])
+        __origin_of(self._storage._find_ref("").unsafe_get[T]())
     ] T:
         """Gets a resource.
 
@@ -192,7 +192,7 @@ struct Resources(ExplicitlyCopyable, Movable):
         Returns:
             A reference to the resource.
         """
-        return self._storage._find_ref(get_type_name[T]()).unsafe_get_ptr[T]()[]
+        return self._storage._find_ref(get_type_name[T]()).unsafe_get[T]()
 
     @always_inline
     fn has[T: ResourceType](mut self) -> Bool:

--- a/src/larecs/unsafe_box.mojo
+++ b/src/larecs/unsafe_box.mojo
@@ -171,21 +171,6 @@ struct UnsafeBox(Copyable, Movable):
         self._destructor(self._data)
 
     @always_inline
-    fn unsafe_get_ptr[
-        T: Copyable & Movable
-    ](ref self) -> Pointer[T, __origin_of(self._data)]:
-        """
-        Returns a pointer to the data stored in the box.
-
-        Parameters:
-            T: The type of the element stored in the UnsafeBox.
-
-        Returns:
-            A pointer to the data stored in the box.
-        """
-        return Pointer[T, __origin_of(self._data)](to=self._data.bitcast[T]()[])
-
-    @always_inline
     fn unsafe_get[T: Copyable & Movable](ref self) -> ref [self._data] T:
         """
         Returns a reference to the data stored in the box.
@@ -196,4 +181,4 @@ struct UnsafeBox(Copyable, Movable):
         Returns:
             A reference to the data stored in the box.
         """
-        return self.unsafe_get_ptr[T]()[]
+        return self._data.bitcast[T]()[]

--- a/src/larecs/world.mojo
+++ b/src/larecs/world.mojo
@@ -1054,15 +1054,15 @@ struct World[*component_types: ComponentType](Movable, Sized):
             # as it will not be reflected in the world
             # or may cause a segmentation fault.
 
-            # Get the component
             try:
+                # Get the component
                 ref component = accessor.get[Float64]()
+
+                # Get an unsafe pointer to the memory
+                # location of the component
+                ptr = UnsafePointer(to=component)
             except:
                 return
-
-            # Get an unsafe pointer to the memory
-            # location of the component
-            ptr = UnsafePointer(to=component)
 
             # Load a SIMD of size `simd_width`
             # Note that a strided load is needed if the component as more than one field.

--- a/src/larecs/world.mojo
+++ b/src/larecs/world.mojo
@@ -661,29 +661,6 @@ struct World[*component_types: ComponentType](Movable, Sized):
         ).get_component[T=T](entity_index.index)
 
     @always_inline
-    fn get_ptr[
-        T: ComponentType
-    ](mut self, entity: Entity) raises -> Pointer[
-        T, __origin_of(self._archetypes[0]._data)
-    ]:
-        """Returns a pointer to the given component of the [..entity.Entity].
-
-        Parameters:
-            T: The type of the component.
-
-        Args:
-            entity: The entity to get the component from.
-
-        Raises:
-            Error: If the entity is not alive or does not have the component.
-        """
-        entity_index = self._entities[entity.get_id()]
-        self._assert_alive(entity)
-        return self._archetypes.unsafe_get(
-            index(entity_index.archetype_index)
-        ).get_component_ptr[T=T](entity_index.index)
-
-    @always_inline
     fn set[
         T: ComponentType
     ](mut self, entity: Entity, owned component: T) raises:
@@ -1079,13 +1056,13 @@ struct World[*component_types: ComponentType](Movable, Sized):
 
             # Get the component
             try:
-                component = accessor.get_ptr[Float64]()
+                ref component = accessor.get[Float64]()
             except:
                 return
 
             # Get an unsafe pointer to the memory
             # location of the component
-            ptr = UnsafePointer(to=component[])
+            ptr = UnsafePointer(to=component)
 
             # Load a SIMD of size `simd_width`
             # Note that a strided load is needed if the component as more than one field.

--- a/test/query_test.mojo
+++ b/test/query_test.mojo
@@ -176,8 +176,8 @@ def test_query_component_reference():
 
     i = 0
     for entity in world.query[FlexibleComponent[0]]():
-        a = entity.get_ptr[FlexibleComponent[0]]()
-        a[].y = i
+        ref a = entity.get[FlexibleComponent[0]]()
+        a.y = i
         i += 1
 
     i = 0
@@ -315,8 +315,8 @@ struct QueryOwner[
 
     fn update(self) raises:
         for entity in self._query:
-            f = entity.get_ptr[FlexibleComponent[0]]()
-            f[].x += 1
+            ref f = entity.get[FlexibleComponent[0]]()
+            f.x += 1
 
 
 fn test_query_in_system() raises:
@@ -335,8 +335,8 @@ fn test_query_in_system() raises:
         sys2.update()
 
     for entity in world.query[FlexibleComponent[0]]():
-        f = entity.get_ptr[FlexibleComponent[0]]()
-        assert_equal(f[].x, 21)
+        ref f = entity.get[FlexibleComponent[0]]()
+        assert_equal(f.x, 21)
 
 
 def test_query_lock():

--- a/test/resource_test.mojo
+++ b/test/resource_test.mojo
@@ -89,6 +89,12 @@ def test_resources_get():
     assert_equal(resources.get[Resource1]().value, 30)
     assert_equal(resources.get[Resource2]().value, 40)
 
+    ref resource = resources.get[Resource1]()
+    assert_equal(resource.value, 30)
+
+    resource.value = 50
+    assert_equal(resources.get[Resource1]().value, 50)
+
 
 def test_resource_remove():
     resources = Resources()
@@ -111,22 +117,10 @@ def test_resource_remove():
     assert_false(resources.has[Resource2]())
 
 
-def test_resources_get_ptr():
-    resources = Resources()
-    resources.add(Resource1(10), Resource2(20))
-
-    ref resource = resources.get[Resource1]()
-    assert_equal(resource.value, 10)
-
-    resource.value = 30
-    assert_equal(resources.get[Resource1]().value, 30)
-
-
 def main():
     test_reseource_init()
     test_reseource_has()
     test_resources_add_set()
     test_resource_remove()
     test_resources_get()
-    test_resources_get_ptr()
     print("All tests passed!")

--- a/test/world_test.mojo
+++ b/test/world_test.mojo
@@ -116,16 +116,9 @@ def test_entity_get():
     world.get[Position](entity).x = 123
     assert_equal(world.get[Position](entity).x, 123)
 
-
-def test_entity_get_ptr():
-    world = SmallWorld()
-    pos = Position(1.0, 2.0)
-    vel = Velocity(0.1, 0.2)
-    entity = world.add_entity(pos, vel)
-    assert_equal(world.get[Position](entity).x, pos.x)
-    entity_pos = world.get_ptr[Position](entity)
-    entity_pos[].x = 123
-    assert_equal(world.get[Position](entity).x, 123)
+    ref entity_pos = world.get[Position](entity)
+    entity_pos.x = 456
+    assert_equal(world.get[Position](entity).x, 456)
 
 
 def test_get_archetype_index():
@@ -353,10 +346,10 @@ def test_world_apply():
 
     fn operation(accessor: MutableEntityAccessor) capturing:
         try:
-            pos2 = accessor.get_ptr[Position]()
-            vel2 = accessor.get_ptr[Velocity]()
-            pos2[].x += vel2[].dx
-            pos2[].y += vel2[].dy
+            ref pos2 = accessor.get[Position]()
+            ref vel2 = accessor.get[Velocity]()
+            pos2.x += vel2.dx
+            pos2.y += vel2.dy
         except:
             pass
 
@@ -399,20 +392,20 @@ def test_world_apply_SIMD():
 
     fn operation[simd_width: Int](accessor: MutableEntityAccessor) capturing:
         try:
-            pos2 = accessor.get_ptr[Position]()
-            vel2 = accessor.get_ptr[Velocity]()
+            ref pos2 = accessor.get[Position]()
+            ref vel2 = accessor.get[Velocity]()
 
             alias _load = load2[simd_width]
             alias _store = store2[simd_width]
 
-            x = _load(pos2[].x)
-            y = _load(pos2[].y)
+            x = _load(pos2.x)
+            y = _load(pos2.y)
 
-            x += _load(vel2[].dx)
-            y += _load(vel2[].dy)
+            x += _load(vel2.dx)
+            y += _load(vel2.dy)
 
-            _store(pos2[].x, x)
-            _store(pos2[].y, y)
+            _store(pos2.x, x)
+            _store(pos2.y, y)
         except:
             pass
 
@@ -459,7 +452,6 @@ def main():
     test_set_component()
     test_get_archetype_index()
     test_entity_get()
-    test_entity_get_ptr()
     test_remove_entity()
     test_remove_archetype()
     test_world_has_component()


### PR DESCRIPTION
The new `ref` keyword allows us t store references instead of just making a copy. This makes the `get_ptr` methods obsolete. Hence, these are removed so as to simplify the API and reduce the code base.